### PR TITLE
Add export_whitelisted function.

### DIFF
--- a/bin/util
+++ b/bin/util
@@ -30,3 +30,13 @@ copy_directories() {
     fi
   done
 }
+
+export_whitelisted() {
+  $env_dir=1
+
+  if [ -r $env_dir/BUILD_CONFIG_WHITELIST ]; then
+    for e in $(cat $env_dir/BUILD_CONFIG_WHITELIST); do
+      export "$e=$(cat $env_dir/$e)"
+    done
+  fi
+}


### PR DESCRIPTION
This allows apps to set whitelisted config vars for build on a per-app
basis rather than having the whitelist hard-coded into the buildpack.