### PR TITLE
Set default encoding to UTF-8

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -182,7 +182,7 @@ case \$limit in
   ;;
 esac
 
-export JAVA_TOOL_OPTIONS="-Xmx\${heap}m \$JAVA_TOOL_OPTIONS -Djava.rmi.server.useCodebaseOnly=true"
+export JAVA_TOOL_OPTIONS="-Xmx\${heap}m -Dfile.encoding=UTF-8 \$JAVA_TOOL_OPTIONS -Djava.rmi.server.useCodebaseOnly=true"
 EOF
 }
 


### PR DESCRIPTION
Without this we found that the default encoding for the JVM (within the flynn/slugrunner container) was "ANSI_X3.4-1968", which caused some characters to be incorrectly encoded within our Groovy templates:

    root@2a87fd0031fc:/app/tmp/groovy-2.3.8# bin/groovy -e 'println(System.getProperty("file.encoding"))'
    Picked up JAVA_TOOL_OPTIONS: -Xmx384m -Xmx384m -Djava.rmi.server.useCodebaseOnly=true -Djava.rmi.server.useCodebaseOnly=true
    ANSI_X3.4-1968

    root@2a87fd0031fc:/app/tmp/groovy-2.3.8# export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8 $JAVA_TOOL_OPTIONS"
    Picked up JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF-8 -Xmx384m -Xmx384m -Djava.rmi.server.useCodebaseOnly=true -Djava.rmi.server.useCodebaseOnly=true
    UTF-8

Please let me know if there is a better solution to this problem.

Thanks

Tom