### PR TITLE
Changing echo command in release script.

### DIFF
--- a/bin/release
+++ b/bin/release
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-echo ""
+echo -n ""


### PR DESCRIPTION
Fixes #17.

Adding the in `-n` flag to the echo command prevents a newline character from being added in the `.release` file. This makes the file size of the resulting `.release` file to 0 as originally intended.