### PR TITLE
Adds -k to cURL command when uploading heaps to S3

### DIFF
--- a/opt/with_jmap_and_jstack_java
+++ b/opt/with_jmap_and_jstack_java
@@ -12,7 +12,7 @@ do
   if [ -z "$JMAP_INTERVAL" ] || [ -z "$JSTACK_INTERVAL" ]; then
     sleep 10
   else
-    seconds=$(date +%s) 
+    seconds=$(date +%s)
     if [ $(($seconds % $JSTACK_INTERVAL)) -eq 0 ]; then
       kill -3 $pid
     fi
@@ -33,7 +33,7 @@ do
               stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
               signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${AWS_SECRET_ACCESS_KEY} -binary | base64`
 
-              curl -s -X PUT -T "${dumpFile}" \
+              curl -s -k -X PUT -T "${dumpFile}" \
               -H "Host: ${S3_BUCKET_NAME}.s3.amazonaws.com" \
               -H "Date: $dateValue" \
               -H "Content-Type: $contentType" \

--- a/opt/with_jmap_java
+++ b/opt/with_jmap_java
@@ -28,7 +28,7 @@ do
             stringToSign="PUT\n\n${contentType}\n${dateValue}\n${resource}"
             signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${AWS_SECRET_ACCESS_KEY} -binary | base64`
 
-            curl -s -X PUT -T "${dumpFile}" \
+            curl -s -k -X PUT -T "${dumpFile}" \
             -H "Host: ${S3_BUCKET_NAME}.s3.amazonaws.com" \
             -H "Date: $dateValue" \
             -H "Content-Type: $contentType" \


### PR DESCRIPTION
The `-k` argument bypasses cURL's standard SSL-certificate checking. This is necessary when uploading to S3 because Amazon requires HTTP connections be made to hosts of the form `<bucketname>.s3.amazonaws.com` but only provides an SSL certificate valid for the `s3.amazonaws.com` domain. Without the `-k` argument, cURL attempts the upload but closes the connection when the SSL certificate verification fails. This failure is never reported, though, since cURL only reports SSL failure when verbose output is enabled (and silence [`-s`] is enabled anyways).

@jkutner 