### PR TITLE
Modify jvmcommon.sh profile script to work with Dash and Bash

### DIFF
--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -21,15 +21,15 @@ case $limit in
   ;;
 esac
 
-if [[ "${JAVA_OPTS}" == *-Xmx* ]]; then
+if echo "${JAVA_OPTS}" | grep -q "\-Xmx"; then
   export JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:-"-Dfile.encoding=UTF-8"}
 else
   default_java_opts="${default_java_mem_opts} -Dfile.encoding=UTF-8"
   export JAVA_OPTS="${default_java_opts} $JAVA_OPTS"
-  if [[ "${DYNO}" != *run.* ]]; then
+  if echo "${DYNO}" | grep -vq "^run.*"; then
     export JAVA_TOOL_OPTIONS="${default_java_opts} $JAVA_TOOL_OPTIONS"
   fi
-  if [[ "${DYNO}" == *web.* ]]; then
+  if echo "${DYNO}" | grep -q "^web.*"; then
     echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them."
   fi
 fi


### PR DESCRIPTION
This is required for Docker, which runs `.profile.d` scripts with `/bin/sh` instead of Bash.