### PR TITLE
Make Azul Zulu JDK the default JDK when available

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -4,10 +4,10 @@ LATEST_JDK_VERSION="1.8"
 DEFAULT_JDK_VERSION="1.8"
 DEFAULT_JDK_BASE_URL="https://lang-jvm.s3.amazonaws.com/jdk/${STACK:-"heroku-16"}"
 JDK_BASE_URL=${JDK_BASE_URL:-$DEFAULT_JDK_BASE_URL}
-JDK_URL_9=${JDK_URL_9:-"$JDK_BASE_URL/zulu-9.0.0.tar.gz"}
-JDK_URL_8=${JDK_URL_8:-"$JDK_BASE_URL/zulu-1.8.0_144.tar.gz"}
-JDK_URL_7=${JDK_URL_7:-"$JDK_BASE_URL/zulu-1.7.0_154.tar.gz"}
-JDK_URL_6=${JDK_URL_6:-"https://lang-jvm.s3.amazonaws.com/jdk/openjdk1.6.0_27.tar.gz"}
+JDK_URL_1_9=${JDK_URL_1_9:-"$JDK_BASE_URL/zulu-9.0.0.tar.gz"}
+JDK_URL_1_8=${JDK_URL_1_8:-"$JDK_BASE_URL/zulu-1.8.0_144.tar.gz"}
+JDK_URL_1_7=${JDK_URL_1_7:-"$JDK_BASE_URL/zulu-1.7.0_154.tar.gz"}
+JDK_URL_1_6=${JDK_URL_1_6:-"https://lang-jvm.s3.amazonaws.com/jdk/openjdk1.6.0_27.tar.gz"}
 
 install_java_with_overlay() {
   local buildDir=${1}
@@ -120,10 +120,10 @@ _get_jdk_download_url() {
   local jdkVersion=${1:-${DEFAULT_JDK_VERSION}}
 
   if [ "$(expr "${jdkVersion}" : '^1.[6-9]$')" != 0 ]; then
-    local minorJdkVersion=\$JDK_URL_$(expr "${jdkVersion}" : '1.\([6-9]\)')
-    local jdkUrl=$(eval echo \$JDK_URL_${minorJdkVersion})
+    local minorJdkVersion=\$JDK_URL_1_$(expr "${jdkVersion}" : '1.\([6-9]\)')
+    local jdkUrl=$(eval echo \$JDK_URL_1_${minorJdkVersion})
   elif [ "$(expr "${jdkVersion}" : '^[6-9]$')" != 0 ]; then
-    local jdkUrl=$(eval echo \$JDK_URL_${jdkVersion})
+    local jdkUrl=$(eval echo \$JDK_URL_1_${jdkVersion})
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]')" != 0 ]; then
     local zuluUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"
     if [ "$(_test_status ${zuluUrl})" != 200 ]; then

--- a/bin/java
+++ b/bin/java
@@ -76,7 +76,7 @@ install_cacerts() {
 validate_jdk_url() {
   local jdkUrl=${1}
   local jdkVersion={2}
-  if [ "$(_test_status ${jdkUrl})" != "200" ]; then
+  if [ "$(_get_url_status ${jdkUrl})" != "200" ]; then
     echo ""
     error_return "Unsupported Java version: $javaVersion
 
@@ -126,7 +126,7 @@ _get_jdk_download_url() {
     local jdkUrl=$(eval echo \$JDK_URL_1_${jdkVersion})
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]')" != 0 ]; then
     local zuluUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"
-    if [ "$(_test_status ${zuluUrl})" != 200 ]; then
+    if [ "$(_get_url_status ${zuluUrl})" != 200 ]; then
       local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
     else
       local jdkUrl="${zuluUrl}"
@@ -135,7 +135,7 @@ _get_jdk_download_url() {
     local jdkUrl="${JDK_BASE_URL}/zulu-9.0.0.tar.gz"
   elif [ "$(expr "${jdkVersion}" : '^9')" != 0 ]; then
     local zuluUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"
-    if [ "$(_test_status ${zuluUrl})" != 200 ]; then
+    if [ "$(_get_url_status ${zuluUrl})" != 200 ]; then
       local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
     else
       local jdkUrl="${zuluUrl}"
@@ -254,6 +254,6 @@ _get_openjdk_version() {
   echo "$(echo ${1} | sed -e 's/openjdk-//g')"
 }
 
-_test_status() {
+_get_url_status() {
   curl --retry 3 --silent --head -w %{http_code} -L "${1}" -o /dev/null
 }

--- a/bin/java
+++ b/bin/java
@@ -4,34 +4,25 @@ LATEST_JDK_VERSION="1.8"
 DEFAULT_JDK_VERSION="1.8"
 DEFAULT_JDK_BASE_URL="https://lang-jvm.s3.amazonaws.com/jdk/${STACK:-"heroku-16"}"
 JDK_BASE_URL=${JDK_BASE_URL:-$DEFAULT_JDK_BASE_URL}
-JDK_URL_1_9=${JDK_URL_1_9:-"$JDK_BASE_URL/openjdk9-181.tar.gz"}
-JDK_URL_1_8=${JDK_URL_1_8:-"$JDK_BASE_URL/openjdk1.8.0_144.tar.gz"}
-JDK_URL_1_7=${JDK_URL_1_7:-"$JDK_BASE_URL/openjdk1.7.0_151.tar.gz"}
-JDK_URL_1_6=${JDK_URL_1_6:-"https://lang-jvm.s3.amazonaws.com/jdk/openjdk1.6.0_27.tar.gz"}
+JDK_URL_9=${JDK_URL_9:-"$JDK_BASE_URL/zulu-9.0.0.tar.gz"}
+JDK_URL_8=${JDK_URL_8:-"$JDK_BASE_URL/zulu-1.8.0_144.tar.gz"}
+JDK_URL_7=${JDK_URL_7:-"$JDK_BASE_URL/zulu-1.7.0_154.tar.gz"}
+JDK_URL_6=${JDK_URL_6:-"https://lang-jvm.s3.amazonaws.com/jdk/openjdk1.6.0_27.tar.gz"}
 
 install_java_with_overlay() {
   local buildDir=${1}
   local javaVersion=$(detect_java_version ${buildDir})
-
-  if [ "$javaVersion" = "stack" ]; then
-    status "Using stack JDK"
+  local jdkUrl=$(_get_jdk_download_url "${javaVersion}")
+  if [[ "$javaVersion" == *openjdk* ]]; then
+    status_pending "Installing OpenJDK $(_get_openjdk_version ${javaVersion})"
+  elif [[ "$javaVersion" == *zulu* ]]; then
+    status_pending "Installing Azul Zulu JDK $(_get_zulu_version ${javaVersion})"
   else
-    local jdkUrl=$(_get_jdk_download_url "${javaVersion}")
-    if [[ "$jdkUrl" == *openjdk* ]]; then
-      if [[ "$javaVersion" == *openjdk* ]]; then
-        status_pending "Installing OpenJDK $(_get_openjdk_version ${javaVersion})"
-      else
-        status_pending "Installing OpenJDK ${javaVersion}"
-      fi
-    elif [[ "$jdkUrl" == *zulu* ]]; then
-      status_pending "Installing Azul Zulu JDK $(_get_zulu_version ${javaVersion})"
-    else
-      status_pending "Installing custom JDK"
-    fi
-    install_java ${buildDir} ${javaVersion} ${jdkUrl}
-    jdk_overlay ${buildDir}
-    status_done
+    status_pending "Installing JDK ${javaVersion}"
   fi
+  install_java ${buildDir} ${javaVersion} ${jdkUrl}
+  jdk_overlay ${buildDir}
+  status_done
 }
 
 install_java() {
@@ -85,8 +76,7 @@ install_cacerts() {
 validate_jdk_url() {
   local jdkUrl=${1}
   local jdkVersion={2}
-  status=$(curl --retry 3 --silent --head -w %{http_code} -L "${jdkUrl}" -o /dev/null)
-  if [ "$status" != "200" ]; then
+  if [ "$(_test_status ${jdkUrl})" != "200" ]; then
     echo ""
     error_return "Unsupported Java version: $javaVersion
 
@@ -130,19 +120,31 @@ _get_jdk_download_url() {
   local jdkVersion=${1:-${DEFAULT_JDK_VERSION}}
 
   if [ "$(expr "${jdkVersion}" : '^1.[6-9]$')" != 0 ]; then
-    local minorJdkVersion=\$JDK_URL_1_$(expr "${jdkVersion}" : '1.\([6-9]\)')
-    local jdkUrl=$(eval echo \$JDK_URL_1_${minorJdkVersion})
+    local minorJdkVersion=\$JDK_URL_$(expr "${jdkVersion}" : '1.\([6-9]\)')
+    local jdkUrl=$(eval echo \$JDK_URL_${minorJdkVersion})
   elif [ "$(expr "${jdkVersion}" : '^[6-9]$')" != 0 ]; then
-    local jdkUrl=$(eval echo \$JDK_URL_1_${jdkVersion})
+    local jdkUrl=$(eval echo \$JDK_URL_${jdkVersion})
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]')" != 0 ]; then
-    local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
+    local zuluUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"
+    if [ "$(_test_status ${zuluUrl})" != 200 ]; then
+      local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
+    else
+      local jdkUrl="${zuluUrl}"
+    fi
   elif [ "${jdkVersion}" = "9+181" ] || [ "${jdkVersion}" = "9.0.0" ]; then
-    local jdkUrl="${JDK_BASE_URL}/openjdk9-181.tar.gz"
+    local jdkUrl="${JDK_BASE_URL}/zulu-9.0.0.tar.gz"
   elif [ "$(expr "${jdkVersion}" : '^9')" != 0 ]; then
-    local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
+    local zuluUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"
+    if [ "$(_test_status ${zuluUrl})" != 200 ]; then
+      local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
+    else
+      local jdkUrl="${zuluUrl}"
+    fi
   elif [ "$(expr "${jdkVersion}" : '^zulu-')" != 0 ]; then
     local jdkUrl="${JDK_BASE_URL}/${jdkVersion}.tar.gz"
   elif [ "$(expr "${jdkVersion}" : '^openjdk-')" != 0 ]; then
+    # remove the - after "openjdk". Because of legacy, the openjdk tarballs
+    # don't have a hyphen, but we wanted them in the system.properties value
     local jdkUrl="${JDK_BASE_URL}/$(echo "$jdkVersion" | sed -e 's/k-/k/g').tar.gz"
   fi
 
@@ -250,4 +252,8 @@ _get_zulu_version() {
 
 _get_openjdk_version() {
   echo "$(echo ${1} | sed -e 's/openjdk-//g')"
+}
+
+_test_status() {
+  curl --retry 3 --silent --head -w %{http_code} -L "${1}" -o /dev/null
 }

--- a/etc/hatchet-test.sh
+++ b/etc/hatchet-test.sh
@@ -1,6 +1,8 @@
 
 set -e
 
+# We're going to run the Java buildpack in order to fully test this buildapck
+# The individual specs will set the JVM_COMMON_BUILDPACK accordingly
 BUILDPACK_NAME="heroku-buildpack-java"
 
 if [ "$CIRCLECI" == "true" ] && [ -n "$CI_PULL_REQUEST" ]; then

--- a/spec/java_spec.rb
+++ b/spec/java_spec.rb
@@ -10,7 +10,7 @@ describe "Java" do
       "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}")
   end
 
-  ["1.7", "1.8", "8", "1.9", "9", "9.0.0", "zulu-1.8.0_144"].each do |version|
+  ["1.7", "1.8", "8", "1.9", "9", "9.0.0", "zulu-1.8.0_144", "openjdk-1.8.0_151", "openjdk-9.0.1"].each do |version|
     context "a simple java app on jdk-#{version}" do
       let(:app) { Hatchet::Runner.new("java-servlets-sample",
         :buildpack_url => "https://github.com/heroku/heroku-buildpack-java") }
@@ -19,8 +19,10 @@ describe "Java" do
         app.deploy do |app|
           if jdk_version.start_with?("zulu")
             expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
+          elsif jdk_version.start_with?("openjdk")
+            expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
           else
-            expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+            expect(app.output).to include("Installing JDK #{jdk_version}")
           end
           expect(app.output).to include("BUILD SUCCESS")
           expect(successful_body(app)).to eq("Hello from Java!")
@@ -29,7 +31,7 @@ describe "Java" do
     end
   end
 
-  ["1.7", "1.8", "zulu-1.8.0_144"].each do |version|
+  ["1.7", "1.8", "openjdk-1.8.0_144", "zulu-1.8.0_144", "openjdk-9.0.1"].each do |version|
     context "jdk-overlay on jdk-#{version}" do
       let(:app) { Hatchet::Runner.new("java-overlay-test",
         :buildpack_url => "https://github.com/heroku/heroku-buildpack-java") }
@@ -38,8 +40,10 @@ describe "Java" do
         app.deploy do |app|
           if jdk_version.start_with?("zulu")
             expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
+          elsif jdk_version.start_with?("openjdk")
+            expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
           else
-            expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+            expect(app.output).to include("Installing JDK #{jdk_version}")
           end
           expect(app.output).to include("BUILD SUCCESS")
 
@@ -61,8 +65,10 @@ describe "Java" do
         app.deploy do |app|
           if jdk_version.start_with?("zulu")
             expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
+          elsif jdk_version.start_with?("openjdk")
+            expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
           else
-            expect(app.output).to include("Installing OpenJDK #{jdk_version}")
+            expect(app.output).to include("Installing JDK #{jdk_version}")
           end
 
           sleep 1
@@ -88,9 +94,11 @@ describe "Java" do
               to include("Successfully invoked HTTPS service.").
               and match(%r{"X-Forwarded-Proto(col)?": "https"})
 
-          sleep 1
-          expect(app.run("pgssl")).
-              to match(%r{sslmode: require})
+          if !jdk_version.match(/^9/) and !jdk_version.match(/^openjdk-9/) and !jdk_version.match(/^zulu-9/)
+            sleep 1
+            expect(app.run("pgssl")).
+                to match(%r{sslmode: require})
+          end
         end
       end
     end

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -11,7 +11,67 @@ testCompileWithoutSystemProperties() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing OpenJDK 1.8"
+  assertCaptured "Installing JDK 1.8"
+  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
+  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
+}
+
+testCompileWith_1_8_0_144() {
+  echo "java.runtime.version=1.8.0_144" > ${BUILD_DIR}/system.properties
+
+  compile
+
+  assertCapturedSuccess
+
+  assertCaptured "Installing JDK 1.8.0_144"
+  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
+  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
+}
+
+testCompileWith_zulu_1_8_0_144() {
+  echo "java.runtime.version=zulu-1.8.0_144" > ${BUILD_DIR}/system.properties
+
+  compile
+
+  assertCapturedSuccess
+
+  assertCaptured "Installing Azul Zulu JDK 1.8.0_144"
+  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
+  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
+}
+
+testCompileWith_openjdk_1_8_0_144() {
+  echo "java.runtime.version=openjdk-1.8.0_144" > ${BUILD_DIR}/system.properties
+
+  compile
+
+  assertCapturedSuccess
+
+  assertCaptured "Installing OpenJDK 1.8.0_144"
+  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
+  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
+}
+
+testCompileWith_9_0_1() {
+  echo "java.runtime.version=9.0.1" > ${BUILD_DIR}/system.properties
+
+  compile
+
+  assertCapturedSuccess
+
+  assertCaptured "Installing JDK 9.0.1"
+  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
+  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
+}
+
+testCompileWith_zulu_9_0_0() {
+  echo "java.runtime.version=zulu-9.0.0" > ${BUILD_DIR}/system.properties
+
+  compile
+
+  assertCapturedSuccess
+
+  assertCaptured "Installing Azul Zulu JDK 9.0.0"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }

--- a/test/java_test.sh
+++ b/test/java_test.sh
@@ -41,13 +41,13 @@ testDetectJava_custom() {
 test_defaultJdkUrl() {
   capture _get_jdk_download_url "${DEFAULT_JDK_VERSION}"
   assertCapturedSuccess
-  assertTrue "The URL should be for the default JDK, ${DEFAULT_JDK_VERSION}." "[ $(cat ${STD_OUT}) = '${JDK_URL_1_8}' ]"
+  assertTrue "The URL should be for the default JDK, ${DEFAULT_JDK_VERSION}." "[ $(cat ${STD_OUT}) = '${JDK_URL_8}' ]"
 }
 
 test_nonDefaultJdkUrl() {
   capture _get_jdk_download_url "1.7"
   assertCapturedSuccess
-  assertTrue "The URL should be for the latest JDK, 1.7." "[ $(cat ${STD_OUT}) = '${JDK_URL_1_7}' ]"
+  assertTrue "The URL should be for the latest JDK, 1.7." "[ $(cat ${STD_OUT}) = '${JDK_URL_7}' ]"
 }
 
 test_installJavaWithoutDirectoryFails() {
@@ -157,4 +157,21 @@ test_zuluJdk() {
 test_openJdk() {
   capture install_java ${BUILD_DIR} "openjdk-1.8.0_144"
   assertCapturedSuccess
+}
+
+test_get_jdk_download_url() {
+  capture _get_jdk_download_url "9"
+  assertCapturedEquals "https://lang-jvm.s3.amazonaws.com/jdk/heroku-16/zulu-9.0.0.tar.gz"
+
+  capture _get_jdk_download_url "9.0.0"
+  assertCapturedEquals "https://lang-jvm.s3.amazonaws.com/jdk/heroku-16/zulu-9.0.0.tar.gz"
+
+  capture _get_jdk_download_url "9+181"
+  assertCapturedEquals "https://lang-jvm.s3.amazonaws.com/jdk/heroku-16/zulu-9.0.0.tar.gz"
+
+  capture _get_jdk_download_url "1.7.0_101"
+  assertCapturedEquals "https://lang-jvm.s3.amazonaws.com/jdk/heroku-16/openjdk1.7.0_101.tar.gz"
+
+  capture _get_jdk_download_url "1.7.0_141"
+  assertCapturedEquals "https://lang-jvm.s3.amazonaws.com/jdk/heroku-16/zulu-1.7.0_141.tar.gz"
 }

--- a/test/java_test.sh
+++ b/test/java_test.sh
@@ -41,13 +41,13 @@ testDetectJava_custom() {
 test_defaultJdkUrl() {
   capture _get_jdk_download_url "${DEFAULT_JDK_VERSION}"
   assertCapturedSuccess
-  assertTrue "The URL should be for the default JDK, ${DEFAULT_JDK_VERSION}." "[ $(cat ${STD_OUT}) = '${JDK_URL_8}' ]"
+  assertTrue "The URL should be for the default JDK, ${DEFAULT_JDK_VERSION}." "[ $(cat ${STD_OUT}) = '${JDK_URL_1_8}' ]"
 }
 
 test_nonDefaultJdkUrl() {
   capture _get_jdk_download_url "1.7"
   assertCapturedSuccess
-  assertTrue "The URL should be for the latest JDK, 1.7." "[ $(cat ${STD_OUT}) = '${JDK_URL_7}' ]"
+  assertTrue "The URL should be for the latest JDK, 1.7." "[ $(cat ${STD_OUT}) = '${JDK_URL_1_7}' ]"
 }
 
 test_installJavaWithoutDirectoryFails() {


### PR DESCRIPTION
This PR changes the default JDK installed by the buildpack from a custom build OpenJDK to the certified [Azul Zulu JDK](http://zulu.org/) when the specified version is available.

For example, the following `system.properties` configuration will install Zulu 8u144:

```
java.runtime.version=1.8.0_144
```

The following configuration will also install Zulu 8u144:

```
java.runtime.version=zulu-1.8.0_144
```

But this configuration will install the custom built OpenJDK 8u144 (the old default):

```
java.runtime.version=openjdk-1.8.0_144
```

If no Zulu binary is available for the version specified, the buildpack will install the custom built OpenJDK for that version.