### PR TITLE
Added function to install heroku-metrics-agent

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -65,6 +65,7 @@ install_java() {
   _create_export_script ${JAVA_HOME} "$(pwd)"
   _install_pgconfig ${JAVA_HOME}
   _install_default_proc_warn ${baseDir}
+  _install_metrics_agent ${baseDir}
 }
 
 install_cacerts() {
@@ -253,4 +254,19 @@ _get_url_status() {
 
 _jvm_mcount() {
   if type -t mcount > /dev/null; then mcount "jvm.${1}"; fi
+}
+
+_install_metrics_agent() {
+  local ctxDir=${1:-BUILD_DIR}
+  local curDir=${JVM_COMMON_DIR:-$(cd $(dirname ${BASH_SOURCE[0]}) && cd .. && pwd )}
+  local binDir="${ctxDir}/.heroku/bin/"
+  local agent_jar="${binDir}/heroku-metrics-agent.jar"
+
+  mkdir -p ${binDir}
+  curl --retry 3 -s -o ${agent_jar} \
+      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.1/heroku-java-metrics-agent-3.1.jar"}
+  [ ! -f ${agent_jar} ] && warning_inline "failed to install metrics agent!"
+
+  mkdir -p ${ctxDir}/.profile.d
+  cp $curDir/opt/heroku-metrics-daemon.sh $ctxDir/.profile.d/
 }

--- a/opt/heroku-metrics-daemon.sh
+++ b/opt/heroku-metrics-daemon.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# TODO set -eu
+
+# don't do anything if we don't have a metrics url.
+if [[ -z "${HEROKU_METRICS_URL:-}" ]] || [[ "${DYNO}" = run\.* ]]; then
+    return 0
+fi
+
+# heroku-metrics-agent.jar is added in bin/compile
+if [[ -f ${HOME}/.heroku/bin/heroku-metrics-agent.jar ]] && [[ -z "${DISABLE_HEROKU_METRICS_AGENT:-}" ]]; then
+  if [[ -f build.sbt ]] || # Scala
+     [[ -d target/resolution-cache ]]; then # Scala (sbt-heroku)
+    export JAVA_OPTS="-javaagent:${HOME}/.heroku/bin/heroku-metrics-agent.jar ${JAVA_OPTS:-}"
+  else
+    export JAVA_TOOL_OPTIONS="-javaagent:${HOME}/.heroku/bin/heroku-metrics-agent.jar ${JAVA_TOOL_OPTIONS:-}"
+  fi
+fi

--- a/test/java_test.sh
+++ b/test/java_test.sh
@@ -130,6 +130,14 @@ test_install_tools() {
   assertTrue "The with_jmap file should be executable." "[ -x ${BUILD_DIR}/.heroku/bin/with_jstack ]"
 }
 
+test_install_metrics_agent() {
+  unset JAVA_HOME # unsets environment -- shunit doesn't clean environment before each test
+  capture _install_metrics_agent ${BUILD_DIR}
+  assertCapturedSuccess
+  assertTrue "The heroku-metrics-agent.jar file should have been created." "[ -f ${BUILD_DIR}/.heroku/bin/heroku-metrics-agent.jar ]"
+  assertTrue "The heroku-metrics-daemon script should have been created." "[ -f ${BUILD_DIR}/.profile.d/heroku-metrics-daemon.sh ]"
+}
+
 test_create_export_script() {
   unset JAVA_HOME # unsets environment -- shunit doesn't clean environment before each test
   capture _create_export_script "/path/to/jdk" ${BUILD_DIR}


### PR DESCRIPTION
This replicates the behavior of the [`heroku/metrics`](https://github.com/heroku/heroku-buildpack-metrics/) buildpack. When this change is released, we can deprecate the `heroku/metrics` buildpack for Java apps.

Because both this buildpack and the `heroku/metrics` buildpack write the `.profile.d/heroku-metrics-daemon.sh` file, both buildpacks can be set on an app without conflicting (one will overwrite the other and the last will win). *But* we will still roll-out a change that removes the Java agent from the `heroku/metrics` buildpack before releasing this.