### PR TITLE
Added LD_LIBRARY_PATH to export and profile.d scripts

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -227,6 +227,7 @@ _create_export_script() {
     cat << EOF > ${ctxDir}/export
 export JAVA_HOME=$javaHome
 export PATH=\$JAVA_HOME/bin:\$PATH
+export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:\$LD_LIBRARY_PATH"
 EOF
   fi
 }

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 export JAVA_HOME="$HOME/.jdk"
+export LD_LIBRARY_PATH="$JAVA_HOME/jre/lib/amd64/server:$LD_LIBRARY_PATH"
 export PATH="$HOME/.heroku/bin:$JAVA_HOME/bin:$PATH"
 limit=$(ulimit -u)
 case $limit in


### PR DESCRIPTION
Some non-Java applications, such as libraries that execute Java from another language, require the `libjvm.so` on the `LD_LIBRARY_PATH`. This change will make that available both during the build and at runtime.

The `java` command itself is able to locate the `libjvm.so` on it's own, so this change is purely for non-Java apps.

Fixes #31 