### PR TITLE
Ensure all profile.d scripts work with 'set -eu'

### DIFF
--- a/opt/heroku-metrics-daemon.sh
+++ b/opt/heroku-metrics-daemon.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# TODO set -eu
-
 # don't do anything if we don't have a metrics url.
 if [[ -z "${HEROKU_METRICS_URL:-}" ]] || [[ "${DYNO}" = run\.* ]]; then
     return 0

--- a/opt/jdbc.sh
+++ b/opt/jdbc.sh
@@ -4,7 +4,7 @@ set_jdbc_url() {
   local db_url=${1}
   local env_prefix=${2:-"JDBC_DATABASE"}
 
-  if [ -z "$(eval echo \$${env_prefix}_URL)" ]; then
+  if [ -z "$(eval echo \${${env_prefix}_URL:-})" ]; then
       local db_protocol=$(expr "$db_url" : "\(.\+\)://")
       if [ "$db_protocol" = "postgres" ]; then
         local jdbc_protocol="jdbc:postgresql"
@@ -43,24 +43,24 @@ set_jdbc_url() {
   fi
 }
 
-if [ -n "$DATABASE_URL" ]; then
+if [ -n "${DATABASE_URL:-}" ]; then
   set_jdbc_url "$DATABASE_URL"
-elif [ -n "$JAWSDB_URL" ]; then
+elif [ -n "${JAWSDB_URL:-}" ]; then
   set_jdbc_url "$JAWSDB_URL"
-elif [ -n "$JAWSDB_MARIA_URL" ]; then
+elif [ -n "${JAWSDB_MARIA_URL:-}" ]; then
   set_jdbc_url "$JAWSDB_MARIA_URL"
-elif [ -n "$CLEARDB_DATABASE_URL" ]; then
+elif [ -n "${CLEARDB_DATABASE_URL:-}" ]; then
   set_jdbc_url "$CLEARDB_DATABASE_URL"
 fi
 
-if [ "$DISABLE_SPRING_DATASOURCE_URL" != "true" ] &&
-   [ -n "$JDBC_DATABASE_URL" ] &&
-   [ -z "$SPRING_DATASOURCE_URL" ] &&
-   [ -z "$SPRING_DATASOURCE_USERNAME" ] &&
-   [ -z "$SPRING_DATASOURCE_PASSWORD" ]; then
+if [ "${DISABLE_SPRING_DATASOURCE_URL:-}" != "true" ] &&
+   [ -n "${JDBC_DATABASE_URL:-}" ] &&
+   [ -z "${SPRING_DATASOURCE_URL:-}" ] &&
+   [ -z "${SPRING_DATASOURCE_USERNAME:-}" ] &&
+   [ -z "${SPRING_DATASOURCE_PASSWORD:-}" ]; then
   export SPRING_DATASOURCE_URL="$JDBC_DATABASE_URL"
-  export SPRING_DATASOURCE_USERNAME="$JDBC_DATABASE_USERNAME"
-  export SPRING_DATASOURCE_PASSWORD="$JDBC_DATABASE_PASSWORD"
+  export SPRING_DATASOURCE_USERNAME="${JDBC_DATABASE_USERNAME:-}"
+  export SPRING_DATASOURCE_PASSWORD="${JDBC_DATABASE_PASSWORD:-}"
 fi
 
 for dbUrlVar in $(env | awk -F "=" '{print $1}' | grep "HEROKU_POSTGRESQL_.*_URL"); do

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -21,13 +21,13 @@ case $limit in
   ;;
 esac
 
-if echo "${JAVA_OPTS}" | grep -q "\-Xmx"; then
+if echo "${JAVA_OPTS:-}" | grep -q "\-Xmx"; then
   export JAVA_TOOL_OPTIONS=${JAVA_TOOL_OPTIONS:-"-Dfile.encoding=UTF-8"}
 else
   default_java_opts="${default_java_mem_opts} -Dfile.encoding=UTF-8"
-  export JAVA_OPTS="${default_java_opts} $JAVA_OPTS"
+  export JAVA_OPTS="${default_java_opts} ${JAVA_OPTS:-}"
   if echo "${DYNO}" | grep -vq '^run\..*$'; then
-    export JAVA_TOOL_OPTIONS="${default_java_opts} $JAVA_TOOL_OPTIONS"
+    export JAVA_TOOL_OPTIONS="${default_java_opts} ${JAVA_TOOL_OPTIONS:-}"
   fi
   if echo "${DYNO}" | grep -q '^web\..*$'; then
     echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them."


### PR DESCRIPTION
This change results from @dzuelke's finding[1] that `set -eu` in a `.profile.d` script can carry over to subsequent `.profile.d` scripts. For that reason, we don't want to add `set -eu` to all JVM `.profile.d` scripts because that could cause other `.profile.d` scripts to fail (inadvertently causing unexpected failures that would be very difficult to diagnose). But we do want to ensure that our scripts work with the `set -eu` directive, in case other buildpacks or customer scripts do `set -eu`.

[1] https://groups.google.com/a/salesforce.com/forum/?hl=en#!topic/heroku-languages-team/ciyhB_k87Bo