### PR TITLE
Fix some Bash issues

### DIFF
--- a/bin/util
+++ b/bin/util
@@ -80,7 +80,7 @@ copy_directories() {
   if [ ! -d "${destDir}" ] ; then echo "Invalid destination directory to copy to. ${destDir}" ; return 1 ; fi
 
   for dir in ${dirList} ; do
-    rm -rf "${destDir}/${dir}"
+    rm -rf "${destDir:?}/${dir:?}"
 
     if [ -d "${sourceDir}/${dir}" ] ; then
       mkdir -p "${destDir}/${dir}"

--- a/etc/hatchet-test.sh
+++ b/etc/hatchet-test.sh
@@ -41,4 +41,4 @@ export HATCHET_APP_LIMIT=20
 export HATCHET_DEPLOY_STRATEGY=git
 export HATCHET_BUILDPACK_BASE="https://github.com/heroku/$BUILDPACK_NAME"
 
-bundle exec parallel_rspec -n 5 $@
+bundle exec parallel_rspec -n 5 "$@"

--- a/opt/with_jmap_and_jstack_java
+++ b/opt/with_jmap_and_jstack_java
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export JAVA_HOME=${HEROKU_JAVA_HOME}
-eval "$JAVA_HOME/bin/java $@ &"
+eval "$JAVA_HOME/bin/java $* &"
 pid=$!
 
 trap "kill -9 $pid; exit" SIGKILL

--- a/opt/with_jmap_java
+++ b/opt/with_jmap_java
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export JAVA_HOME=${HEROKU_JAVA_HOME}
-eval "$JAVA_HOME/bin/java $@ &"
+eval "$JAVA_HOME/bin/java $* &"
 pid=$!
 
 trap "kill -9 $pid; exit" SIGKILL

--- a/opt/with_jstack_java
+++ b/opt/with_jstack_java
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 export JAVA_HOME=${HEROKU_JAVA_HOME}
-eval "$JAVA_HOME/bin/java $@ &"
+eval "$JAVA_HOME/bin/java $* &"
 pid=$!
 
 trap "kill -3 $pid; kill $pid" SIGTERM


### PR DESCRIPTION
Use `"${var:?}"` to ensure this never expands to `/` .
Double quote array expansions, otherwise they're like `$*` and break on spaces.
Argument mixes string and array. Use `*` or separate argument.