### PR TITLE
Upgrade heroku-java-metrics-agent to version 3.7

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -265,7 +265,7 @@ _install_metrics_agent() {
 
   mkdir -p ${binDir}
   curl --retry 3 -s -o ${agent_jar} \
-      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.4/heroku-java-metrics-agent-3.4.jar"}
+      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.5/heroku-java-metrics-agent-3.5.jar"}
   [ ! -f ${agent_jar} ] && warning_inline "failed to install metrics agent!"
 
   mkdir -p ${ctxDir}/.profile.d

--- a/bin/java
+++ b/bin/java
@@ -265,7 +265,7 @@ _install_metrics_agent() {
 
   mkdir -p ${binDir}
   curl --retry 3 -s -o ${agent_jar} \
-      -L ${HEROKU_METRICS_JAR_URL:-"http://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.5/heroku-java-metrics-agent-3.5.jar"}
+      -L ${HEROKU_METRICS_JAR_URL:-"https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.5/heroku-java-metrics-agent-3.5.jar"}
   [ ! -f ${agent_jar} ] && warning_inline "failed to install metrics agent!"
 
   mkdir -p ${ctxDir}/.profile.d

--- a/bin/java
+++ b/bin/java
@@ -265,7 +265,7 @@ _install_metrics_agent() {
 
   mkdir -p ${binDir}
   curl --retry 3 -s -o ${agent_jar} \
-      -L ${HEROKU_METRICS_JAR_URL:-"https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.5/heroku-java-metrics-agent-3.5.jar"}
+      -L ${HEROKU_METRICS_JAR_URL:-"https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.7/heroku-java-metrics-agent-3.7.jar"}
   [ ! -f ${agent_jar} ] && warning_inline "failed to install metrics agent!"
 
   mkdir -p ${ctxDir}/.profile.d


### PR DESCRIPTION
Adds support for cURL when the Java HTTP client fails to connect. This is often due to a custom `cacerts` bundle that does don't include the Metric's URL's CA.