### PR TITLE
Added message when JDK install is skipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## master
 
 * Added support for JDK 11 EA
+* Improve logging when using a provided JDK
 
 ## v66
 

--- a/bin/java
+++ b/bin/java
@@ -13,22 +13,27 @@ JDK_URL_1_6=${JDK_URL_1_6:-"https://lang-jvm.s3.amazonaws.com/jdk/openjdk1.6.0_2
 
 install_java_with_overlay() {
   local buildDir=${1}
-  local jdkVersion=$(detect_java_version ${buildDir})
-  local jdkUrl=$(_get_jdk_download_url "${jdkVersion}")
-  _jvm_mcount "version.${jdkVersion}"
-  if [[ "$jdkVersion" == *openjdk* ]]; then
-    status_pending "Installing OpenJDK $(_get_openjdk_version ${jdkVersion})"
-    _jvm_mcount "vendor.openjdk"
-  elif [[ "$jdkVersion" == *zulu* ]]; then
-    status_pending "Installing Azul Zulu JDK $(_get_zulu_version ${jdkVersion})"
-    _jvm_mcount "vendor.zulu"
+  if [ ! -f "${buildDir}/.jdk/bin/java" ]; then
+    local jdkVersion=$(detect_java_version ${buildDir})
+    local jdkUrl=$(_get_jdk_download_url "${jdkVersion}")
+    _jvm_mcount "version.${jdkVersion}"
+    if [[ "$jdkVersion" == *openjdk* ]]; then
+      status_pending "Installing OpenJDK $(_get_openjdk_version ${jdkVersion})"
+      _jvm_mcount "vendor.openjdk"
+    elif [[ "$jdkVersion" == *zulu* ]]; then
+      status_pending "Installing Azul Zulu JDK $(_get_zulu_version ${jdkVersion})"
+      _jvm_mcount "vendor.zulu"
+    else
+      status_pending "Installing JDK ${jdkVersion}"
+      _jvm_mcount "vendor.default"
+    fi
+    install_java ${buildDir} ${jdkVersion} ${jdkUrl}
+    jdk_overlay ${buildDir}
+    status_done
   else
-    status_pending "Installing JDK ${jdkVersion}"
-    _jvm_mcount "vendor.default"
+    status "Using provided JDK"
+    _jvm_mcount "vendor.provided"
   fi
-  install_java ${buildDir} ${jdkVersion} ${jdkUrl}
-  jdk_overlay ${buildDir}
-  status_done
 }
 
 install_java() {

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -87,3 +87,15 @@ testCompileWith_10() {
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
+
+test_skip_install_if_java_exists() {
+  mkdir -p ${BUILD_DIR}/.jdk/bin
+  touch ${BUILD_DIR}/.jdk/bin/java
+
+  compile
+
+  assertCapturedSuccess
+  assertCaptured "Using provided JDK"
+  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
+  assertTrue "Java files should not have been installed." "[ ! -f ${BUILD_DIR}/.jdk/jre/lib/amd64/server/libjvm.so ]"
+}


### PR DESCRIPTION
This is helpful when an alternative jvm-common buildpack is used with a buildpack that imports this buildpack. For example:

```
$ heroku buildpacks:add https://github.com/heroku/heroku-buildpack-jvm-common.git
$ heroku buildpacks:add heroku/java
```