### PR TITLE
Convert server side connection pool URL to JDBC

### DIFF
--- a/opt/jdbc.sh
+++ b/opt/jdbc.sh
@@ -45,6 +45,9 @@ set_jdbc_url() {
 
 if [ -n "${DATABASE_URL:-}" ]; then
   set_jdbc_url "$DATABASE_URL"
+  if [ -n "${DATABASE_CONNECTION_POOL_URL:-}" ]; then
+    set_jdbc_url "$DATABASE_CONNECTION_POOL_URL"
+  fi
 elif [ -n "${JAWSDB_URL:-}" ]; then
   set_jdbc_url "$JAWSDB_URL"
 elif [ -n "${JAWSDB_MARIA_URL:-}" ]; then


### PR DESCRIPTION
If server-side connection pooling is configured for the primary database as per [the guide](https://devcenter.heroku.com/articles/postgres-connection-pooling#enabling-connection-pooling) it currently will not get a JDBC compatible URL generated.