### PR TITLE
Check for a target dir when detecting lein-heroku apps

### DIFF
--- a/bin/detect
+++ b/bin/detect
@@ -19,7 +19,7 @@ elif [ -f $1/pom.xml ] && [ -d $1/target ]; then
   echo "heroku-maven-plugin"
 elif [ -d $1/target/universal/stage ]; then
   echo "sbt-heroku"
-elif [ -f $1/project.clj ]; then
+elif [ -f $1/project.clj ] && [ -d $1/target ]; then
   echo "lein-heroku"
 else
   echo "JVM Common"

--- a/test/detect_test.sh
+++ b/test/detect_test.sh
@@ -31,6 +31,7 @@ testDetect_OldSbtPlugin()
 testDetect_OldLeinPlugin()
 {
   touch ${BUILD_DIR}/project.clj
+  mkdir ${BUILD_DIR}/target
 
   detect
 


### PR DESCRIPTION
This prevents the buildpack from mistaking the app for a `lein-heroku` app when it's just in conjunction with the `heroku/clojure` buildpack and Git deploys.