### PR TITLE
Remove default Xms value in JAVA_TOOL_OPTIONS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Changed default JDK 7 to 7u201
 * Changed default JDK 11 to 11.0.2
 * Changed default JDK 8 to 8u201
+* Remove Xms from default JAVA_TOOL_OPTIONS
 
 ## 73
 

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -9,10 +9,10 @@ calculate_java_memory_opts() {
     echo "$opts -Xmx671m -XX:CICompilerCount=2"
     ;;
   16384) # perf-m, private-m: memory.limit_in_bytes=2684354560
-    echo "$opts -Xms512m -Xmx2g"
+    echo "$opts -Xmx2g"
     ;;
   32768) # perf-l, private-l: memory.limit_in_bytes=15032385536
-    echo "$opts -Xms1g -Xmx12g"
+    echo "$opts -Xmx12g"
     ;;
   *) # Free, Hobby, 1X: memory.limit_in_bytes=536870912
     echo "$opts -Xmx300m -Xss512k -XX:CICompilerCount=2"


### PR DESCRIPTION
The default `Xms` values where only providing minor performance gains (milliseconds), but where causing problems for tools that set `Xmx` very low.

See https://github.com/gradle/gradle/issues/8182