### PR TITLE
Cache JVM version

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -292,6 +292,10 @@ _install_metrics_agent() {
   cp $curDir/opt/heroku-jvm-metrics.sh $ctxDir/.profile.d/
 }
 
+# Caching the JVM version will allow us to pin previous used defaults when
+# upgrading the default JDK. That is, if an app has JDK 8 installed now
+# because it's the default, it will continue to have JDK 8 installed when the
+# default is upgraded to JDK 11.
 _cache_version() {
   local jdkVersion="${1}"
   local cacheDir="${2}"

--- a/bin/java
+++ b/bin/java
@@ -30,7 +30,7 @@ install_java_with_overlay() {
     fi
     install_java "${buildDir}" "${jdkVersion}" "${jdkUrl}"
     jdk_overlay "${buildDir}"
-    _cache_version "${jdkVersion:-default}" "${cacheDir}"
+    _cache_version "${jdkVersion}" "${cacheDir}"
     status_done
   else
     status "Using provided JDK"

--- a/bin/java
+++ b/bin/java
@@ -45,7 +45,7 @@ install_java() {
     return 1
   fi
 
-  local jdkVersion=${2:-$(get_default_java_version)}
+  local jdkVersion="${2:-$DEFAULT_JDK_VERSION}"
   local jdkUrl=${3:-$(_get_jdk_download_url "${jdkVersion}")}
   local jdkDir="${baseDir}"/.jdk
   local jdkTarball="${jdkDir}"/jdk.tar.gz
@@ -160,10 +160,6 @@ _get_jdk_download_url() {
   echo "${jdkUrl}"
 }
 
-get_default_java_version() {
-  echo "$DEFAULT_JDK_VERSION"
-}
-
 detect_java_version() {
   baseDir=${1:-"No Dir"}
   if [ "${baseDir}" = "No Dir" ] || [ ! -d "${baseDir}" ] ; then
@@ -172,13 +168,13 @@ detect_java_version() {
   fi
   if [ -f ${baseDir}/system.properties ]; then
     detectedVersion="$(get_app_system_value ${baseDir}/system.properties "java.runtime.version")"
-    if [ -z "$detectedVersion" ]; then
-      echo "$DEFAULT_JDK_VERSION"
+    if [ -n "$detectedVersion" ]; then
+      echo "$detectedVersion"
     else
-      echo "$(get_default_java_version)"
+      echo "$DEFAULT_JDK_VERSION"
     fi
   else
-    echo "$(get_default_java_version)"
+    echo "$DEFAULT_JDK_VERSION"
   fi
 }
 

--- a/bin/java
+++ b/bin/java
@@ -172,7 +172,12 @@ detect_java_version() {
     return 1
   fi
   if [ -f ${baseDir}/system.properties ]; then
-    echo "$(get_app_system_value ${baseDir}/system.properties "java.runtime.version")"
+    detectedVersion="$(get_app_system_value ${baseDir}/system.properties "java.runtime.version")"
+    if [ -z "$detectedVersion" ]; then
+      echo "$DEFAULT_JDK_VERSION"
+    else
+      echo "$(get_default_java_version)"
+    fi
   else
     echo "$(get_default_java_version)"
   fi

--- a/bin/java
+++ b/bin/java
@@ -12,8 +12,8 @@ JDK_URL_1_7=${JDK_URL_1_7:-"$JDK_BASE_URL/openjdk1.7.0_201.tar.gz"}
 JDK_URL_1_6=${JDK_URL_1_6:-"https://lang-jvm.s3.amazonaws.com/jdk/openjdk1.6.0_27.tar.gz"}
 
 install_java_with_overlay() {
-  local buildDir=${1}
-  local cacheDir=${2:-$(mktemp -d)}
+  local buildDir="${1}"
+  local cacheDir="${2:-$(mktemp -d)}"
   if [ ! -f "${buildDir}/.jdk/bin/java" ]; then
     local jdkVersion=$(detect_java_version ${buildDir})
     local jdkUrl=$(_get_jdk_download_url "${jdkVersion}")
@@ -28,9 +28,9 @@ install_java_with_overlay() {
       status_pending "Installing JDK ${jdkVersion}"
       _jvm_mcount "vendor.default"
     fi
-    install_java ${buildDir} ${jdkVersion} ${jdkUrl}
-    jdk_overlay ${buildDir}
-    _cache_version ${jdkVersion} ${cacheDir}
+    install_java "${buildDir}" "${jdkVersion}" "${jdkUrl}"
+    jdk_overlay "${buildDir}"
+    _cache_version "${jdkVersion:-default}" "${cacheDir}"
     status_done
   else
     status "Using provided JDK"
@@ -292,5 +292,5 @@ _cache_version() {
   local jdkVersion="${1}"
   local cacheDir="${2}"
 
-  echo "java.runtime.version=${jdkVersion}" > ${cacheDir}/system.properties
+  echo "java.runtime.version=${jdkVersion}" > "${cacheDir}/system.properties"
 }

--- a/spec/java_spec.rb
+++ b/spec/java_spec.rb
@@ -32,24 +32,14 @@ describe "Java" do
     end
   end
 
-  context "a system.properties file with no java.runtime-version" do
+  context "a system.properties file with no java.runtime.version" do
     let(:app) { Hatchet::Runner.new("java-servlets-sample",
       :buildpack_url => "https://github.com/heroku/heroku-buildpack-java") }
-    let(:jdk_version) { "8" }
+    let(:jdk_version) { "1.8" }
     it "should deploy" do
-      File.delete('system.properties')
-      File.open('system.properties', 'w') do |f|
-        f.puts "maven.version=3.3.9"
-      end
-      `git add system.properties && git commit -m "unsetting jdk version"`
+      write_sys_props app.directory, "maven.version=3.3.9"
       app.deploy do |app|
-        if jdk_version.start_with?("zulu")
-          expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
-        elsif jdk_version.start_with?("openjdk")
-          expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
-        else
-          expect(app.output).to include("Installing JDK #{jdk_version}")
-        end
+        expect(app.output).to include("Installing JDK #{jdk_version}")
         expect(app.output).to include("BUILD SUCCESS")
         expect(successful_body(app)).to eq("Hello from Java!")
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,9 +50,14 @@ def create_file_with_size_in(size, dir)
 end
 
 def set_java_version(d, v)
+  write_sys_props d, "java.runtime.version=#{v}"
+end
+
+def write_sys_props(d, props)
   Dir.chdir(d) do
+    `rm -f system.properties`
     File.open('system.properties', 'w') do |f|
-      f.puts "java.runtime.version=#{v}"
+      f.puts props
     end
     `git add system.properties && git commit -m "setting jdk version"`
   end

--- a/test/java_test.sh
+++ b/test/java_test.sh
@@ -38,6 +38,12 @@ testDetectJava_custom() {
   assertCapturedEquals "1.7"
 }
 
+testDetectJava_default() {
+  echo "maven.version=3.3.9" >> ${BUILD_DIR}/system.properties
+  capture detect_java_version ${BUILD_DIR}
+  assertCapturedEquals "1.8"
+}
+
 test_defaultJdkUrl() {
   capture _get_jdk_download_url "${DEFAULT_JDK_VERSION}"
   assertCapturedSuccess


### PR DESCRIPTION
This PR caches the resolved value of `java.runtime.version`. To support this, I've also changed the behavior of `detect_java_version` such that it returns the default version when a `system.properties` file is present, but does not have a `java.runtime.version` property.

Caching the JVM version will allow us to pin previous used defaults when upgrading the default JDK. That is, if an app has JDK 8 installed now because it's the default, it will continue to have JDK 8 installed when the default is upgraded to JDK 11.