### PR TITLE
Implement use of CNB build plan [changelog skip]

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -20,7 +20,7 @@ set -eu
 bp_install_or_reuse_toolbox "${layersDir}/utils"
 export PATH="$PATH:${layersDir}/utils/bin"
 
-jdkVersion="$(get_jdk_version "${appDir}")"
+jdkVersion="$(get_jdk_version "${appDir}")" # TODO read from build-plan instead
 
 jdkUrl="$(get_jdk_url "${jdkVersion}")"
 

--- a/bin/detect
+++ b/bin/detect
@@ -13,7 +13,38 @@ get_client() {
   fi
 }
 
+write_build_plan() {
+  local plan=${1:?}
+  local appDir="$(pwd)"
+  local bpDir="$(cd $(dirname $0)/..; pwd)" # absolute path
+  source "${bpDir}/lib/jvm.sh"
+
+  local jdkVersion="$(get_jdk_version "${appDir}")"
+  local fullJdkVersion="$(get_full_jdk_version "${jdkVersion}")"
+
+  cat <<TOML > $plan
+[[provides]]
+name = "jdk"
+
+[[requires]]
+name = "jdk"
+version = "$fullJdkVersion"
+[[requires.metadata]]
+launch = false
+
+[[provides]]
+name = "jre"
+
+[[requires]]
+name = "jre"
+version = "$fullJdkVersion"
+[[requires.metadata]]
+launch = true
+TOML
+}
+
 if [ -n "${CNB_STACK_ID:-}" ]; then
+  write_build_plan "$2"
   echo "JVM"
 else
   if [ -f $1/.heroku-deploy ]; then

--- a/bin/java
+++ b/bin/java
@@ -12,7 +12,7 @@ install_java_with_overlay() {
   local cacheDir="${2:-$(mktemp -d)}"
   if [ ! -f "${buildDir}/.jdk/bin/java" ]; then
     local jdkVersion=$(get_jdk_version ${buildDir})
-    local jdkUrl=$(get_jdk_url "${jdkVersion}")
+    local jdkUrl=$(_get_jdk_url_with_default "${jdkVersion}")
     _jvm_mcount "version.${jdkVersion}"
     if [[ "$jdkVersion" == *openjdk* ]]; then
       status_pending "Installing OpenJDK $(_get_openjdk_version ${jdkVersion})"
@@ -38,7 +38,7 @@ install_java() {
   local baseDir=${1?"Invalid directory to install java."}
 
   local jdkVersion="${2:-$DEFAULT_JDK_VERSION}"
-  local jdkUrl=${3:-$(get_jdk_url "${jdkVersion}")}
+  local jdkUrl=${3:-$(_get_jdk_url_with_default "${jdkVersion}")}
   local jdkDir="${baseDir}"/.jdk
   local jdkTarball="${jdkDir}"/jdk.tar.gz
   local javaExe="${jdkDir}/bin/java"
@@ -151,6 +151,30 @@ _install_pgconfig() {
 
   if [ -d "${extDir}" ] && [ -z "${SKIP_PGCONFIG_INSTALL:-}"  ] && [ "${CI:-}" != "true" ]; then
     curl --retry 3 -s -L "https://lang-jvm.s3.amazonaws.com/pgconfig.jar" -o ${extDir}/pgconfig.jar
+  fi
+}
+
+# This function implements a legacy behavior in which the JDK_URL_1_8 or similar config var
+# could be used to override the URL to the JDK binary for a specific version. It's
+# not supported in the v3 implementation of the buildpack.
+_get_jdk_url_with_default() {
+  local jdkVersion="${1:?}"
+  if [ -n "${JDK_URL_1_7:-}" ] && ([ "$(expr "${jdkVersion}" : '^1.7')" != 0 ] || [ "$(expr "${jdkVersion}" : '^7')" != 0 ]); then
+    echo "$JDK_URL_1_7"
+  elif [ -n "${JDK_URL_1_8:-}" ] && ([ "$(expr "${jdkVersion}" : '^1.8')" != 0 ] || [ "$(expr "${jdkVersion}" : '^8')" != 0 ]); then
+    echo "$JDK_URL_1_8"
+  elif [ -n "${JDK_URL_1_9:-}" ] && ([ "$(expr "${jdkVersion}" : '^1.9')" != 0 ] || [ "$(expr "${jdkVersion}" : '^9')" != 0 ]); then
+    echo "$JDK_URL_1_9"
+  elif [ -n "${JDK_URL_10:-}" ] && [ "$(expr "${jdkVersion}" : '^10')" != 0 ]; then
+    echo "$JDK_URL_10"
+  elif [ -n "${JDK_URL_11:-}" ] && [ "$(expr "${jdkVersion}" : '^11')" != 0 ]; then
+    echo "$JDK_URL_11"
+  elif [ -n "${JDK_URL_12:-}" ] && [ "$(expr "${jdkVersion}" : '^12')" != 0 ]; then
+    echo "$JDK_URL_12"
+  elif [ -n "${JDK_URL_13:-}" ] && [ "$(expr "${jdkVersion}" : '^13')" != 0 ]; then
+    echo "$JDK_URL_13"
+  else
+    echo "$(get_jdk_url "$jdkVersion")"
   fi
 }
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -5,15 +5,15 @@
 
 STACK="${STACK:-$CNB_STACK_ID}"
 DEFAULT_JDK_VERSION="1.8"
+DEFAULT_JDK_1_7_VERSION="1.7.0_242"
+DEFAULT_JDK_1_8_VERSION="1.8.0_232"
+DEFAULT_JDK_1_9_VERSION="9.0.4"
+DEFAULT_JDK_10_VERSION="10.0.2"
+DEFAULT_JDK_11_VERSION="11.0.5"
+DEFAULT_JDK_12_VERSION="12.0.2"
+DEFAULT_JDK_13_VERSION="13.0.1"
 DEFAULT_JDK_BASE_URL="https://lang-jvm.s3.amazonaws.com/jdk/${STACK:-"heroku-18"}"
 JDK_BASE_URL=${JDK_BASE_URL:-$DEFAULT_JDK_BASE_URL}
-JDK_URL_13=${JDK_URL_13:-"$JDK_BASE_URL/openjdk13.0.1.tar.gz"}
-JDK_URL_12=${JDK_URL_12:-"$JDK_BASE_URL/openjdk12.0.2.tar.gz"}
-JDK_URL_11=${JDK_URL_11:-"$JDK_BASE_URL/openjdk11.0.5.tar.gz"}
-JDK_URL_10=${JDK_URL_10:-"$JDK_BASE_URL/openjdk10.0.2.tar.gz"}
-JDK_URL_1_9=${JDK_URL_1_9:-"$JDK_BASE_URL/openjdk9.0.4.tar.gz"}
-JDK_URL_1_8=${JDK_URL_1_8:-"$JDK_BASE_URL/openjdk1.8.0_232.tar.gz"}
-JDK_URL_1_7=${JDK_URL_1_7:-"$JDK_BASE_URL/openjdk1.7.0_242.tar.gz"}
 
 get_jdk_version() {
   local appDir="${1:?}"
@@ -29,24 +29,35 @@ get_jdk_version() {
   fi
 }
 
-get_jdk_url() {
-  local jdkVersion=${1:-${DEFAULT_JDK_VERSION}}
+get_full_jdk_version() {
+  local jdkVersion="${1:?}"
 
   if [ "${jdkVersion}" = "10" ]; then
-    local jdkUrl="${JDK_URL_10}"
+    echo "$DEFAULT_JDK_10_VERSION"
   elif [ "${jdkVersion}" = "11" ]; then
-    local jdkUrl="${JDK_URL_11}"
+    echo "$DEFAULT_JDK_11_VERSION"
   elif [ "${jdkVersion}" = "12" ]; then
-    local jdkUrl="${JDK_URL_12}"
+    echo "$DEFAULT_JDK_12_VERSION"
   elif [ "${jdkVersion}" = "13" ]; then
-    local jdkUrl="${JDK_URL_13}"
-  elif [ "$(expr "${jdkVersion}" : '^1[0-3]')" != 0 ]; then
-    local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
+    echo "$DEFAULT_JDK_13_VERSION"
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]$')" != 0 ]; then
     local minorJdkVersion=$(expr "${jdkVersion}" : '1.\([6-9]\)')
-    local jdkUrl=$(eval echo \$JDK_URL_1_${minorJdkVersion})
+    echo "$(eval echo \$DEFAULT_JDK_1_${minorJdkVersion}_VERSION)"
   elif [ "$(expr "${jdkVersion}" : '^[6-9]$')" != 0 ]; then
-    local jdkUrl=$(eval echo \$JDK_URL_1_${jdkVersion})
+    echo "$(eval echo \$DEFAULT_JDK_1_${jdkVersion}_VERSION)"
+  elif [ "${jdkVersion}" = "9+181" ] || [ "${jdkVersion}" = "9.0.0" ]; then
+    echo "9-181" # the naming convention for the first JDK 9 release was poor
+  else
+    echo "$jdkVersion"
+  fi
+}
+
+get_jdk_url() {
+  local shortJdkVersion=${1:-${DEFAULT_JDK_VERSION}}
+  local jdkVersion="$(get_full_jdk_version "${shortJdkVersion}")"
+
+  if [ "$(expr "${jdkVersion}" : '^1[0-3]')" != 0 ]; then
+    local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]')" != 0 ]; then
     local jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
   elif [ "${jdkVersion}" = "9+181" ] || [ "${jdkVersion}" = "9.0.0" ]; then

--- a/test/unit
+++ b/test/unit
@@ -20,6 +20,20 @@ EOF
   assertEquals "11" "$(get_jdk_version "$BUILD_DIR")"
 }
 
+test_get_full_jdk_version() {
+  assertEquals "${DEFAULT_JDK_1_7_VERSION}" "$(get_full_jdk_version "1.7")"
+  assertEquals "${DEFAULT_JDK_1_8_VERSION}" "$(get_full_jdk_version "1.8")"
+  assertEquals "${DEFAULT_JDK_1_9_VERSION}" "$(get_full_jdk_version "1.9")"
+  assertEquals "${DEFAULT_JDK_1_9_VERSION}" "$(get_full_jdk_version "9")"
+  assertEquals "${DEFAULT_JDK_10_VERSION}" "$(get_full_jdk_version "10")"
+  assertEquals "${DEFAULT_JDK_11_VERSION}" "$(get_full_jdk_version "11")"
+  assertEquals "${DEFAULT_JDK_12_VERSION}" "$(get_full_jdk_version "12")"
+  assertEquals "${DEFAULT_JDK_13_VERSION}" "$(get_full_jdk_version "13")"
+  assertEquals "1.8.0_212" "$(get_full_jdk_version "1.8.0_212")"
+  assertEquals "11.0.5" "$(get_full_jdk_version "11.0.5")"
+  assertEquals "zulu-11.0.5" "$(get_full_jdk_version "zulu-11.0.5")"
+}
+
 test_get_jdk_version_8_222() {
   echo "java.runtime.version=1.8.0_222" > "${BUILD_DIR}/system.properties"
   assertEquals "1.8.0_222" "$(get_jdk_version "$BUILD_DIR")"
@@ -41,15 +55,21 @@ test_get_jdk_version_zulu() {
 }
 
 test_get_jdk_url() {
-  assertEquals "${JDK_URL_1_8:?}" "$(get_jdk_url "")"
-  assertEquals "${JDK_URL_1_7:?}" "$(get_jdk_url "1.7")"
-  assertEquals "${JDK_URL_1_8:?}" "$(get_jdk_url "1.8")"
-  assertEquals "${JDK_URL_1_9:?}" "$(get_jdk_url "9")"
-  assertEquals "${JDK_URL_11:?}" "$(get_jdk_url "11")"
-  assertEquals "https://lang-jvm.s3.amazonaws.com/jdk/${STACK}/openjdk1.7.0_192.tar.gz" "$(get_jdk_url "1.7.0_192")"
-  assertEquals "https://lang-jvm.s3.amazonaws.com/jdk/${STACK}/openjdk1.8.0_222.tar.gz" "$(get_jdk_url "1.8.0_222")"
-  assertEquals "https://lang-jvm.s3.amazonaws.com/jdk/${STACK}/openjdk1.8.0_191.tar.gz" "$(get_jdk_url "1.8.0_191")"
-  assertEquals "https://lang-jvm.s3.amazonaws.com/jdk/${STACK}/openjdk11.0.0.tar.gz" "$(get_jdk_url "11.0.0")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_1_8_VERSION:?}.tar.gz" "$(get_jdk_url "")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_1_7_VERSION:?}.tar.gz" "$(get_jdk_url "1.7")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_1_8_VERSION:?}.tar.gz" "$(get_jdk_url "1.8")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_1_9_VERSION:?}.tar.gz" "$(get_jdk_url "9")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_10_VERSION:?}.tar.gz" "$(get_jdk_url "10")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_11_VERSION:?}.tar.gz" "$(get_jdk_url "11")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_12_VERSION:?}.tar.gz" "$(get_jdk_url "12")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_13_VERSION:?}.tar.gz" "$(get_jdk_url "13")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.7.0_192.tar.gz" "$(get_jdk_url "1.7.0_192")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_222.tar.gz" "$(get_jdk_url "1.8.0_222")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_191.tar.gz" "$(get_jdk_url "1.8.0_191")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk11.0.0.tar.gz" "$(get_jdk_url "11.0.0")"
+  assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_212.tar.gz" "$(get_jdk_url "zulu-1.8.0_212")"
+  assertEquals "${JDK_BASE_URL:?}/zulu-11.0.5.tar.gz" "$(get_jdk_url "zulu-11.0.5")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_212.tar.gz" "$(get_jdk_url "openjdk-1.8.0_212")"
 }
 
 test_install_jdk_overlay() {

--- a/test/utils
+++ b/test/utils
@@ -27,6 +27,7 @@ setUp()
   STD_ERR="${OUTPUT_DIR}/stderr"
   BUILD_DIR="${OUTPUT_DIR}/build"
   LAYERS_DIR="${OUTPUT_DIR}/layers"
+  PLATFORM_DIR="${OUTPUT_DIR}/platform"
   mkdir -p ${OUTPUT_DIR}
   mkdir -p ${BUILD_DIR}
   mkdir -p ${LAYERS_DIR}
@@ -74,7 +75,7 @@ detect()
 {
   cd ${BUILD_DIR}
   if [ -n "${CNB_STACK_ID:-}" ]; then
-    capture ${BUILDPACK_HOME}/bin/detect # todo: add platform dir and build plan
+    capture ${BUILDPACK_HOME}/bin/detect "$1" "$2"
   else
     capture ${BUILDPACK_HOME}/bin/detect "${BUILD_DIR}"
   fi

--- a/test/v2
+++ b/test/v2
@@ -211,6 +211,27 @@ test_skip_version_cache() {
   assertTrue "Version should not be cached" "[ ! -f fake_dir/system.properties ]"
 }
 
+test_get_jdk_url_with_default() {
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_232.tar.gz" "$(_get_jdk_url_with_default "1.8.0_232")"
+
+  export JDK_URL_1_8="https://example.com/java8"
+  assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_232")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.7.0_232.tar.gz" "$(_get_jdk_url_with_default "1.7.0_232")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk11.0.5.tar.gz" "$(_get_jdk_url_with_default "11.0.5")"
+  assertEquals "${JDK_BASE_URL:?}/zulu-11.0.5.tar.gz" "$(_get_jdk_url_with_default "zulu-11.0.5")"
+  unset JDK_URL_1_8
+
+  export JDK_URL_1_7="https://example.com/java7"
+  assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_232")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_232.tar.gz" "$(_get_jdk_url_with_default "1.8.0_232")"
+  unset JDK_URL_1_7
+
+  export JDK_URL_11="https://example.com/java11"
+  assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.5")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_232.tar.gz" "$(_get_jdk_url_with_default "1.8.0_232")"
+  unset JDK_URL_11
+}
+
 # the modules to be tested
 source "${BUILDPACK_HOME}/bin/java"
 

--- a/test/v3
+++ b/test/v3
@@ -4,9 +4,34 @@ export BUILDPACK_HOME="${BUILDPACK_HOME:-$(pwd)}"
 
 testDetect()
 {
-  detect
+  local buildPlan="$(mktemp)"
+  detect "${PLATFORM_DIR}" "${buildPlan}"
 
   assertAppDetected "JVM"
+  assertFileExists "${buildPlan}"
+  assertFileContains "version = \"${DEFAULT_JDK_1_8_VERSION}\"" "${buildPlan}"
+}
+
+testDetect_jdk11()
+{
+  echo "java.runtime.version=11" > ${BUILD_DIR}/system.properties
+  local buildPlan="$(mktemp)"
+  detect "${PLATFORM_DIR}" "${buildPlan}"
+
+  assertAppDetected "JVM"
+  assertFileExists "${buildPlan}"
+  assertFileContains "version = \"${DEFAULT_JDK_11_VERSION}\"" "${buildPlan}"
+}
+
+testDetect_jdk11_0_4()
+{
+  echo "java.runtime.version=11.0.4" > ${BUILD_DIR}/system.properties
+  local buildPlan="$(mktemp)"
+  detect "${PLATFORM_DIR}" "${buildPlan}"
+
+  assertAppDetected "JVM"
+  assertFileExists "${buildPlan}"
+  assertFileContains "version = \"11.0.4\"" "${buildPlan}"
 }
 
 test_get_jdk_cache_id() {


### PR DESCRIPTION
This required some rework of how the config is resolved into a URL, so that we can capture just the full version (and use it to get a URL later)