### PR TITLE
Add legacy functions for backwards compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## master
 
-* SPRING_REDIS_URL is now automatically set if REDIS_URL is available 
+* SPRING_REDIS_URL is now automatically set if REDIS_URL is available
+* Fix backwards compatibility for users of this buildpack as a library
 
 ## v92
 

--- a/bin/java
+++ b/bin/java
@@ -94,6 +94,18 @@ is_java_version_change() {
   test -f "${jdkDir}/version" && [ "$(cat ${jdkDir}/version)" != "${jdkVersion}" ]
 }
 
+# Legacy functions for backwards compatability
+detect_java_version() {
+  get_jdk_version "$1"
+}
+
+jdk_overlay() {
+  local buildDir=$1
+  install_jdk_overlay "${buildDir}/.jdk" "${buildDir}"
+}
+
+# Internal functions
+
 _install_tools() {
   local ctxDir=${1:-BUILD_DIR}
   local curDir=${JVM_COMMON_DIR:-$(cd $(dirname ${BASH_SOURCE[0]}) && cd .. && pwd )}


### PR DESCRIPTION
Commit a42a421760174615235f92713d7266a9c133ff8b moved and renamed some functions, breaking backwards compatibility for users of this buildpack as a library. 

Most importantly [heroku-buildpack-play](https://github.com/heroku/heroku-buildpack-play) did [break](https://stackoverflow.com/questions/59407167/heroku-deploy-fails). Granted, it's deprecated, but could work a while longer with this fix. Other buildpacks maintained by third party authors might be affected as well.

I want to add tests for this to avoid regressions. I am not entirely sure what the best way would be. @jkutner, can you share some insight?