### PR TITLE
Support io.buildpacks.stacks.bionic stack [changelog skip]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * SPRING_REDIS_URL is now automatically set if REDIS_URL is available
 * Fix backwards compatibility for users of this buildpack as a library
+* Add support for `io.buildpacks.stacks.bionic` stack
 
 ## v92
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 * SPRING_REDIS_URL is now automatically set if REDIS_URL is available
 * Fix backwards compatibility for users of this buildpack as a library
-* Add support for `io.buildpacks.stacks.bionic` stack
 
 ## v92
 

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -21,3 +21,6 @@ name = "JVM"
 
 [[stacks]]
 id = "heroku-18"
+
+[[stacks]]
+id = "io.buildpacks.stacks.bionic"

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -22,5 +22,6 @@ name = "JVM"
 [[stacks]]
 id = "heroku-18"
 
+# this is to allow testing of other stack compatibility and is not a guarantee
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
[This RFC](https://github.com/buildpacks/rfcs/pull/40) is working its way through and it seems useful to be able to use Heroku buildpacks on `cloudfoundry/cnb:bionic`. This also aligns with how riff is compatible with [multiple stacks](https://github.com/projectriff/node-function-buildpack/blob/master/buildpack.toml#L22).