### PR TITLE
Use -T when copying the jre directory to a new layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## master
 
+* CNB: Fixed a bug that was cause JRE 11 to be installed incorrectly
 * SPRING_REDIS_URL is now automatically set if REDIS_URL is available
 * Fix backwards compatibility for users of this buildpack as a library
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -174,9 +174,9 @@ install_jre() {
 
   if [ -d "${jdkDir}/jre" ]; then
     rm -rf "${jreDir}"
-    cp -R "${jdkDir}/jre" "${jreDir}"
+    cp -TR "${jdkDir}/jre" "${jreDir}"
   else
-    cp -R "${jdkDir}" "${jreDir}"
+    cp -TR "${jdkDir}" "${jreDir}"
   fi
 }
 

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -20,8 +20,12 @@ calculate_java_memory_opts() {
   esac
 }
 
-export JAVA_HOME="$HOME/.jdk"
-export PATH="$HOME/.heroku/bin:$JAVA_HOME/bin:$PATH"
+if [[ -f $HOME/.jdk ]]; then
+  export JAVA_HOME="$HOME/.jdk"
+  export PATH="$HOME/.heroku/bin:$JAVA_HOME/bin:$PATH"
+else
+  export JAVA_HOME="$(realpath $(dirname $(which java))/..)"
+fi
 
 if [[ -d "$JAVA_HOME/jre/lib/amd64/server" ]]; then
   export LD_LIBRARY_PATH="$JAVA_HOME/jre/lib/amd64/server:$LD_LIBRARY_PATH"
@@ -29,7 +33,7 @@ elif [[ -d "$JAVA_HOME/lib/server" ]]; then
   export LD_LIBRARY_PATH="$JAVA_HOME/lib/server:$LD_LIBRARY_PATH"
 fi
 
-if cat "$HOME/.jdk/release" | grep -q '^JAVA_VERSION="1[0-1]'; then
+if cat "$JAVA_HOME/release" | grep -q '^JAVA_VERSION="1[0-1]'; then
   default_java_mem_opts="$(calculate_java_memory_opts "-XX:+UseContainerSupport")"
 else
   default_java_mem_opts="$(calculate_java_memory_opts | sed 's/^ //')"

--- a/test/unit
+++ b/test/unit
@@ -151,6 +151,18 @@ test_bp_layer_has_key_yes() {
   assertEquals 0 "$?"
 }
 
+test_install_jre() {
+  jdk_dir="${LAYERS_DIR}/jdk"
+  jre_dir="${LAYERS_DIR}/jre"
+  mkdir -p "${jdk_dir}/bin"
+  touch "${jdk_dir}/bin/java"
+  mkdir -p "${jre_dir}"
+  touch "${jre_dir}.toml"
+  install_jre "${jdk_dir}" "${jre_dir}"
+  assertFileExists "${jre_dir}/bin/java"
+  assertFileExists "${jre_dir}.toml"
+}
+
 # the modules to be tested
 source "${BUILDPACK_DIR}/lib/jvm.sh"
 source "${BUILDPACK_DIR}/lib/v3/buildpack.sh"


### PR DESCRIPTION
This fixes a bug where the JRE dir was created as `/layers/heroku_jvm/jre/jdk` instead of `/layers/heroku_jvm/jre/`