### PR TITLE
Fix bp_layer_init() for existing layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * CNB: Fixed a bug that was cause JRE 11 to be installed incorrectly
 * SPRING_REDIS_URL is now automatically set if REDIS_URL is available
 * Fix backwards compatibility for users of this buildpack as a library
+* CNB: Fix JRE/JDK caching
 
 ## v92
 

--- a/lib/v3/buildpack.sh
+++ b/lib/v3/buildpack.sh
@@ -70,6 +70,7 @@ bp_layer_init() {
   local layer_dir="${layers_dir}/${name}"
   local layer_metadata="${layer_dir}.toml"
 
+  rm -rf "${layer_dir}"
   mkdir -p "${layer_dir}"
   echo "${metadata}" > "${layer_metadata}"
 


### PR DESCRIPTION
Initialising a layer that already exists (most likely from cache) will now purge the existing layer before writing metadata. Fixes #125