### PR TITLE
Fix server side connection pool JDBC URL

### DIFF
--- a/opt/jdbc.sh
+++ b/opt/jdbc.sh
@@ -58,7 +58,7 @@ set_jdbc_url() {
 if [ -n "${DATABASE_URL:-}" ]; then
   set_jdbc_url "$DATABASE_URL"
   if [ -n "${DATABASE_CONNECTION_POOL_URL:-}" ]; then
-    set_jdbc_url "$DATABASE_CONNECTION_POOL_URL"
+    set_jdbc_url "$DATABASE_CONNECTION_POOL_URL" "JDBC_DATABASE_CONNECTION_POOL"
   fi
 elif [ -n "${JAWSDB_URL:-}" ]; then
   set_jdbc_url "$JAWSDB_URL"


### PR DESCRIPTION
Calling `set_jdbc_url` after already setting `JDBC_DATABASE_URL` doesn't work unless you pass a new env var to check.

The original change here was to be synonymous with how non-JDBC URLs work when using [server-side connection pooling](https://devcenter.heroku.com/articles/postgres-connection-pooling#enabling-connection-pooling):
`DATABASE_URL` -> non connection pool URL
`DATABASE_CONNECTION_POOL_URL` -> connection pooling URL

so for JDBC, the idea was:
`JDBC_DATABASE_URL` -> non connection pool URL, JDBC format
`JDBC_DATABASE_CONNECTION_POOL_URL` -> connection pooling URL.

However, this is not how it was documented: https://devcenter.heroku.com/articles/connecting-to-relational-databases-on-heroku-with-java#using-with-heroku-postgres-connection-pooling