### PR TITLE
Add support for BP_JVM_VERSION

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* Add support for BP_JVM_VERSION
+
 ## v103
 
 Upgrade default JDK 13 to 13.0.3

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -28,6 +28,16 @@ get_jdk_version() {
     else
       echo "$DEFAULT_JDK_VERSION"
     fi
+  elif [ -n "${BP_JVM_VERSION:-}" ]; then
+    if [ "$(expr "$BP_JVM_VERSION" : '^1\?[0-9]\.\*$')" != 0 ]; then
+      # matches values in the 8.*, 11.*, etc and strips the .*
+      echo "${BP_JVM_VERSION//\.\*/}"
+    elif [ "$(expr "$BP_JVM_VERSION" : '^8\.0\.[0-9]\+')" != 0 ]; then
+      # matches values in the form 8.0.252 and converts them to 1.8.0_252
+      echo "1.8.0_${BP_JVM_VERSION//8\.0\./}"
+    else
+      echo "$BP_JVM_VERSION"
+    fi
   else
     echo "$DEFAULT_JDK_VERSION"
   fi

--- a/test/unit
+++ b/test/unit
@@ -54,6 +54,19 @@ test_get_jdk_version_zulu() {
   assertEquals "zulu-1.8.0_212" "$(get_jdk_version "$BUILD_DIR")"
 }
 
+test_bp_jvm_version() {
+  rm -f "${BUILD_DIR}/system.properties"
+  export BP_JVM_VERSION="8.*"
+  assertEquals "8" "$(get_jdk_version "$BUILD_DIR")"
+  export BP_JVM_VERSION="8.0.252"
+  assertEquals "1.8.0_252" "$(get_jdk_version "$BUILD_DIR")"
+  export BP_JVM_VERSION="11.*"
+  assertEquals "11" "$(get_jdk_version "$BUILD_DIR")"
+  export BP_JVM_VERSION="11.0.7"
+  assertEquals "11.0.7" "$(get_jdk_version "$BUILD_DIR")"
+  unset BP_JVM_VERSION
+}
+
 test_get_jdk_url() {
   assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_1_8_VERSION:?}.tar.gz" "$(get_jdk_url "")"
   assertEquals "${JDK_BASE_URL:?}/openjdk${DEFAULT_JDK_1_7_VERSION:?}.tar.gz" "$(get_jdk_url "1.7")"


### PR DESCRIPTION
This change adds support for the `BP_JVM_VERSION` environment variable used by the [Sprint-Boot Maven plugin](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/maven-plugin/reference/html/#build-image) and [Spring-Boot Gradle plugin](https://docs.spring.io/spring-boot/docs/current-SNAPSHOT/gradle-plugin/reference/html/#build-image) to define a JVM version when building an OCI image with buildpacks.