### PR TITLE
[changelog skip] Hatchet v7.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,44 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3.2)
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
-    concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     erubis (2.7.0)
-    excon (0.75.0)
+    excon (0.76.0)
     heroics (0.1.1)
       erubis (~> 2.0)
       excon
       moneta
       multi_json (>= 1.9.2)
-    heroku_hatchet (6.0.0)
+    heroku_hatchet (7.0.0)
       excon (~> 0)
-      platform-api (= 3.0.0.pre.1)
-      repl_runner (~> 0.0.3)
+      platform-api (~> 3)
       rrrretry (~> 1)
       thor (~> 0)
       threaded (~> 0)
-    i18n (1.8.3)
-      concurrent-ruby (~> 1.0)
-    minitest (5.14.1)
     moneta (1.0.0)
-    multi_json (1.14.1)
+    multi_json (1.15.0)
     parallel (1.19.2)
     parallel_split_test (0.7.0)
       parallel (>= 0.5.13)
       rspec (>= 3.1.0)
-    platform-api (3.0.0.pre.1)
+    platform-api (3.0.0)
       heroics (~> 0.1.1)
       moneta (~> 1.0.0)
       rate_throttle_client (~> 0.1.0)
     rate_throttle_client (0.1.2)
-    repl_runner (0.0.3)
-      activesupport
     rrrretry (1.0.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -56,11 +43,7 @@ GEM
       rspec-core (> 3.3)
     rspec-support (3.9.2)
     thor (0.20.3)
-    thread_safe (0.3.6)
     threaded (0.0.4)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
-    zeitwerk (2.3.1)
 
 PLATFORMS
   ruby
@@ -72,4 +55,4 @@ DEPENDENCIES
   rspec-retry
 
 BUNDLED WITH
-   2.1.2
+   2.1.4


### PR DESCRIPTION
- ActiveSupport's Object#blank? and Object#present? are no longer provided by default (https://github.com/heroku/hatchet/pull/107)
- Remove deprecated support for passing a block to `App#run` (https://github.com/heroku/hatchet/pull/105)
- Ignore  403 on app delete due to race condition (https://github.com/heroku/hatchet/pull/101)
- The hatchet.lock file can now be locked to "main" in addition to "master" (https://github.com/heroku/hatchet/pull/86)
- Allow concurrent one-off dyno runs with the `run_multi: true` flag on apps (https://github.com/heroku/hatchet/pull/94)
- Apps are now marked as being "finished" by enabling maintenance mode on them when `teardown!` is called. Finished apps can be reaped immediately (https://github.com/heroku/hatchet/pull/97)
- Applications that are not marked as "finished" will be allowed to live for a HATCHET_ALIVE_TTL_MINUTES duration before they're deleted by the reaper to protect against deleting an app mid-deploy, default is seven minutes (https://github.com/heroku/hatchet/pull/97)
- The HEROKU_APP_LIMIT env var no longer does anything, instead hatchet application reaping is manually executed if an app cannot be created (https://github.com/heroku/hatchet/pull/97)
- App#deploy without a block will no longer run `teardown!` automatically (https://github.com/heroku/hatchet/pull/97)
- Calls to `git push heroku` are now rate throttled (https://github.com/heroku/hatchet/pull/98)
- Calls to `app.run` are now rate throttled (https://github.com/heroku/hatchet/pull/99)
- Deployment now raises and error when the release failed (https://github.com/heroku/hatchet/pull/93)