### PR TITLE
Fix JDBC unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* JDBC_DATABASE_URL query parameters are now alphabetically ordered.
+
 ## v105
 
 * Upgrade default JDKs to 14.0.2, 13.0.4, 11.0.8, 8u262 and 7u272

--- a/opt/jdbc.sh
+++ b/opt/jdbc.sh
@@ -71,7 +71,9 @@ set_jdbc_url() {
 
     # Fold all query parameters from the associative array into a query string.
     local modified_query
-    for query_parameter_key in "${!query_parameters[@]}"; do
+
+    local -r sorted_query_parameter_keys=$(echo -n "${!query_parameters[@]}" | tr " " "\n" | sort | tr "\n" " ")
+    for query_parameter_key in $sorted_query_parameter_keys; do
       local key_value_pair="${query_parameter_key}=${query_parameters[$query_parameter_key]}"
 
       if [[ -z $modified_query ]]; then

--- a/test/jdbc.sh
+++ b/test/jdbc.sh
@@ -17,7 +17,7 @@ testDefaultDatabaseEnvVar() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?user=AzureDiamond&password=hunter2&sslmode=require" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?password=hunter2&sslmode=require&user=AzureDiamond" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
   )
@@ -33,7 +33,7 @@ testSSLModeDisabledOnCI() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?user=AzureDiamond&password=hunter2" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?password=hunter2&user=AzureDiamond" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
   )
@@ -55,11 +55,11 @@ testColorDatabaseEnvVar() {
 
     assertEquals "" "$JDBC_DATABASE_URL"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/fire-pokemon?user=red&password=charmander&sslmode=require" "$HEROKU_POSTGRESQL_RED_JDBC_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/fire-pokemon?password=charmander&sslmode=require&user=red" "$HEROKU_POSTGRESQL_RED_JDBC_URL"
     assertEquals "red" "$HEROKU_POSTGRESQL_RED_JDBC_USERNAME"
     assertEquals "charmander" "$HEROKU_POSTGRESQL_RED_JDBC_PASSWORD"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/water-pokemon?user=blue&password=squirtle&sslmode=require" "$HEROKU_POSTGRESQL_BLUE_JDBC_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/water-pokemon?password=squirtle&sslmode=require&user=blue" "$HEROKU_POSTGRESQL_BLUE_JDBC_URL"
     assertEquals "blue" "$HEROKU_POSTGRESQL_BLUE_JDBC_USERNAME"
     assertEquals "squirtle" "$HEROKU_POSTGRESQL_BLUE_JDBC_PASSWORD"
   )
@@ -78,7 +78,7 @@ testMySQLDatabaseEnvVar() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:mysql://ec2-0-0-0-0:5432/abc123?user=foo&password=bar&reconnect=true" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:mysql://ec2-0-0-0-0:5432/abc123?password=bar&reconnect=true&user=foo" "$JDBC_DATABASE_URL"
   )
 }
 
@@ -97,7 +97,7 @@ testThirdPartyDatabaseUrls() {
         # shellcheck disable=SC1090
         source "$JDBC_SCRIPT_LOCATION"
 
-        assertEquals "jdbc:mysql://ec2-0-0-0-0:5432/$item?user=foo&password=bar&reconnect=true" "$JDBC_DATABASE_URL"
+        assertEquals "jdbc:mysql://ec2-0-0-0-0:5432/$item?password=bar&reconnect=true&user=foo" "$JDBC_DATABASE_URL"
         assertEquals "foo" "$JDBC_DATABASE_USERNAME"
         assertEquals "bar" "$JDBC_DATABASE_PASSWORD"
       )
@@ -120,7 +120,7 @@ testThirdPartyDatabaseUrlsPriority() {
       # shellcheck disable=SC1090
       source "$JDBC_SCRIPT_LOCATION"
 
-      assertEquals "jdbc:postgresql://db.example.com:5432/regular-database?user=AzureDiamond&password=hunter2&sslmode=require" "$JDBC_DATABASE_URL"
+      assertEquals "jdbc:postgresql://db.example.com:5432/regular-database?password=hunter2&sslmode=require&user=AzureDiamond" "$JDBC_DATABASE_URL"
       assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
       assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
     )
@@ -141,11 +141,11 @@ testDatabaseConnectionPool() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://pooled.example.com:5432/testdb?user=pooluser&password=poolpass&sslmode=require" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://pooled.example.com:5432/testdb?password=poolpass&sslmode=require&user=pooluser" "$JDBC_DATABASE_URL"
     assertEquals "pooluser" "$JDBC_DATABASE_USERNAME"
     assertEquals "poolpass" "$JDBC_DATABASE_PASSWORD"
 
-    assertEquals "jdbc:postgresql://pooled.example.com:5432/testdb?user=pooluser&password=poolpass&sslmode=require" "$DATABASE_CONNECTION_POOL_JDBC_URL"
+    assertEquals "jdbc:postgresql://pooled.example.com:5432/testdb?password=poolpass&sslmode=require&user=pooluser" "$DATABASE_CONNECTION_POOL_JDBC_URL"
     assertEquals "pooluser" "$DATABASE_CONNECTION_POOL_JDBC_USERNAME"
     assertEquals "poolpass" "$DATABASE_CONNECTION_POOL_JDBC_PASSWORD"
   )
@@ -187,7 +187,7 @@ testSpringDataSourceSupport() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?user=AzureDiamond&password=hunter2&sslmode=require" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?password=hunter2&sslmode=require&user=AzureDiamond" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
 
@@ -211,7 +211,7 @@ testSpringDataSourceSupportExplicitlyDisabled() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?user=AzureDiamond&password=hunter2&sslmode=require" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?password=hunter2&sslmode=require&user=AzureDiamond" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
 
@@ -237,7 +237,7 @@ testSpringDataSourceSupportImplicitlyDisabled() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?user=AzureDiamond&password=hunter2&sslmode=require" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?password=hunter2&sslmode=require&user=AzureDiamond" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
 
@@ -283,7 +283,7 @@ testCustomDatabaseUrlWithFragmentAndQueryParameters() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?foo=bar&user=AzureDiamond&password=hunter2&sslmode=require&e=mc^2#fragment" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432/testdb?e=mc^2&foo=bar&password=hunter2&sslmode=require&user=AzureDiamond#fragment" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
   )
@@ -302,7 +302,7 @@ testCustomDatabaseUrlWithoutPath() {
     # shellcheck disable=SC1090
     source "$JDBC_SCRIPT_LOCATION"
 
-    assertEquals "jdbc:postgresql://db.example.com:5432?user=AzureDiamond&password=hunter2&sslmode=require" "$JDBC_DATABASE_URL"
+    assertEquals "jdbc:postgresql://db.example.com:5432?password=hunter2&sslmode=require&user=AzureDiamond" "$JDBC_DATABASE_URL"
     assertEquals "AzureDiamond" "$JDBC_DATABASE_USERNAME"
     assertEquals "hunter2" "$JDBC_DATABASE_PASSWORD"
   )

--- a/test/jdbc.sh
+++ b/test/jdbc.sh
@@ -6,6 +6,8 @@ JDBC_SCRIPT_LOCATION="opt/jdbc.sh"
 
 testDefaultDatabaseEnvVar() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -23,6 +25,8 @@ testDefaultDatabaseEnvVar() {
 
 testSSLModeDisabledOnCI() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     export DATABASE_URL="postgres://AzureDiamond:hunter2@db.example.com:5432/testdb"
     export CI="true"
 
@@ -37,6 +41,8 @@ testSSLModeDisabledOnCI() {
 
 testColorDatabaseEnvVar() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -61,6 +67,8 @@ testColorDatabaseEnvVar() {
 
 testMySQLDatabaseEnvVar() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -75,27 +83,33 @@ testMySQLDatabaseEnvVar() {
 }
 
 testThirdPartyDatabaseUrls() {
-  for item in JAWSDB_URL JAWSDB_MARIA_URL CLEARDB_DATABASE_URL; do
-    (
-      # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
-      # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
-      unset CI
+  (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
 
-      export "$item="mysql://foo:bar@ec2-0-0-0-0:5432/$item?reconnect=true""
+    for item in JAWSDB_URL JAWSDB_MARIA_URL CLEARDB_DATABASE_URL; do
+      (
+        # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
+        # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
+        unset CI
 
-      # shellcheck disable=SC1090
-      source "$JDBC_SCRIPT_LOCATION"
+        export "$item="mysql://foo:bar@ec2-0-0-0-0:5432/$item?reconnect=true""
 
-      assertEquals "jdbc:mysql://ec2-0-0-0-0:5432/$item?user=foo&password=bar&reconnect=true" "$JDBC_DATABASE_URL"
-      assertEquals "foo" "$JDBC_DATABASE_USERNAME"
-      assertEquals "bar" "$JDBC_DATABASE_PASSWORD"
-    )
-  done
+        # shellcheck disable=SC1090
+        source "$JDBC_SCRIPT_LOCATION"
+
+        assertEquals "jdbc:mysql://ec2-0-0-0-0:5432/$item?user=foo&password=bar&reconnect=true" "$JDBC_DATABASE_URL"
+        assertEquals "foo" "$JDBC_DATABASE_USERNAME"
+        assertEquals "bar" "$JDBC_DATABASE_PASSWORD"
+      )
+    done
+  )
 }
 
 testThirdPartyDatabaseUrlsPriority() {
   for item in JAWSDB_URL JAWSDB_MARIA_URL CLEARDB_DATABASE_URL; do
     (
+      set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
       # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
       # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
       unset CI
@@ -115,6 +129,8 @@ testThirdPartyDatabaseUrlsPriority() {
 
 testDatabaseConnectionPool() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -137,6 +153,8 @@ testDatabaseConnectionPool() {
 
 testDatabaseConnectionPoolWithoutDatabaseUrl() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -158,6 +176,8 @@ testDatabaseConnectionPoolWithoutDatabaseUrl() {
 
 testSpringDataSourceSupport() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -179,6 +199,8 @@ testSpringDataSourceSupport() {
 
 testSpringDataSourceSupportExplicitlyDisabled() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -203,6 +225,8 @@ testSpringDataSourceSupportImplicitlyDisabled() {
   local originalSpringDatasourceUrl="jdbc:postgresql://db.example.com:5432/testdb?user=AzureDiamondSpring&password=hunter2&sslmode=require"
 
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -225,6 +249,8 @@ testSpringDataSourceSupportImplicitlyDisabled() {
 
 testCustomDatabaseUrlWithoutPasswordAndPath() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -246,6 +272,8 @@ testCustomDatabaseUrlWithoutPasswordAndPath() {
 
 testCustomDatabaseUrlWithFragmentAndQueryParameters() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI
@@ -263,6 +291,8 @@ testCustomDatabaseUrlWithFragmentAndQueryParameters() {
 
 testCustomDatabaseUrlWithoutPath() {
   (
+    set -e # Exit subshell after failed command, important to make multi-assert tests work properly
+
     # Circle CI sets this environment variable. It causes trouble since the JDBC code checks this variable to see if it
     # is running on Heroku CI and generates different urls in such cases, causing some tests to fail.
     unset CI


### PR DESCRIPTION
Since tests are run in subshells, failed `assert`s might not bubble up to the testrunner. Adding `set -e` to the subshells fixes the issue as the subshells will then terminate on the first error.

This causes the tests to fail (as expected), so the fix for `jdbc.sh` is also included in this PR. Luckily, the issue is just about the ordering of query parameters in the JDBC database URL which does not matter in practice. The order of query parameters is now consistent across bash versions and therefore stacks. The tests have been updated accordingly.