### PR TITLE
Fix export env dir: Add check for existence of env files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Main
 
 * JDBC_DATABASE_URL query parameters are now alphabetically ordered.
+* Fix export_env_dir when no environment variables are present. (#148)
 
 ## v105
 

--- a/bin/util
+++ b/bin/util
@@ -64,8 +64,10 @@ export_env_dir() {
   blacklist_regex=${3:-'^(PATH|GIT_DIR|CPATH|CPPATH|LD_PRELOAD|LIBRARY_PATH|JAVA_OPTS|JAVA_TOOL_OPTIONS)$'}
   if [ -d "$env_dir" ]; then
     for env_var_path in "$env_dir"/*; do
-      basename "$env_var_path" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
-        export "$(basename "$env_var_path")=$(cat "$env_var_path")"
+      if [ -f "$env_var_path" ]; then
+        basename "$env_var_path" | grep -E "$whitelist_regex" | grep -qvE "$blacklist_regex" &&
+          export "$(basename "$env_var_path")=$(cat "$env_var_path")"
+      fi
       :
     done
   fi


### PR DESCRIPTION
Originally opened as #149 but never landed in `main`. This will finally fix #148. This PR uses the original authors commit to properly credit them. :)