### PR TITLE
Add OpenJDK 15 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* Add support for JDK 15
+
 ## v106
 
 * JDBC_DATABASE_URL query parameters are now alphabetically ordered.

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -16,6 +16,8 @@ DEFAULT_JDK_11_VERSION="11.0.8"
 DEFAULT_JDK_12_VERSION="12.0.2"
 DEFAULT_JDK_13_VERSION="13.0.4"
 DEFAULT_JDK_14_VERSION="14.0.2"
+DEFAULT_JDK_15_VERSION="15.0.0"
+
 DEFAULT_JDK_BASE_URL="https://lang-jvm.s3.amazonaws.com/jdk/${STACK:-"heroku-18"}"
 JDK_BASE_URL=${JDK_BASE_URL:-$DEFAULT_JDK_BASE_URL}
 
@@ -56,6 +58,8 @@ get_full_jdk_version() {
     echo "$DEFAULT_JDK_13_VERSION"
   elif [ "${jdkVersion}" = "14" ]; then
     echo "$DEFAULT_JDK_14_VERSION"
+  elif [ "${jdkVersion}" = "15" ]; then
+    echo "$DEFAULT_JDK_15_VERSION"
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]$')" != 0 ]; then
     local minorJdkVersion
     minorJdkVersion=$(expr "${jdkVersion}" : '1.\([6-9]\)')
@@ -76,7 +80,7 @@ get_jdk_url() {
   jdkVersion="$(get_full_jdk_version "${shortJdkVersion}")"
 
   local jdkUrl
-  if [ "$(expr "${jdkVersion}" : '^1[0-4]')" != 0 ]; then
+  if [ "$(expr "${jdkVersion}" : '^1[0-5]')" != 0 ]; then
     jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]')" != 0 ]; then
     jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 describe "Java" do
 
-  ["1.7", "1.8", "8", "1.9", "9", "9.0.0", "10", "11", "12", "13", "14",
+  ["1.7", "1.8", "8", "11", "13", "14", "15",
     "zulu-1.8.0_144", "openjdk-1.8.0_162", "openjdk-9.0.4"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
@@ -56,7 +56,7 @@ describe "Java" do
     end
   end
 
-  ["1.7", "1.8", "openjdk-1.8.0_162", "10", "11", "12", "13", "14",
+  ["1.7", "1.8", "openjdk-1.8.0_162", "11", "13", "14", "15",
     "zulu-1.8.0_144", "openjdk-9.0.4"].each do |jdk_version|
     context "jdk-overlay on #{jdk_version}" do
       it "should deploy" do
@@ -96,7 +96,7 @@ describe "Java" do
     end
   end
 
-  ["1.8", "10", "11", "12", "13", "14"].each do |jdk_version|
+  ["1.8", "11", "13", "14", "15"].each do |jdk_version|
     context "korvan on jdk-#{jdk_version}" do
       it "runs commands" do
         Hatchet::Runner.new(

--- a/test/spec/metrics_spec.rb
+++ b/test/spec/metrics_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
 describe "JVM Metrics" do
-  ["1.7", "1.8", "11", "14"].each do |jdk_version|
+  ["1.7", "1.8", "11", "14", "15"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
         Hatchet::Runner.new(


### PR DESCRIPTION
In addition, this drops testing for EOL major versions (that don't get security patches anymore). Those will be removed from our docs as well since we don't want to encourage their usage.