### PR TITLE
Update skip changelog action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,4 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+      - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -2,7 +2,7 @@ name: Check Changelog
 
 on:
   pull_request:
-    types: [opened, reopened, edited, synchronize]
+    types: [opened, reopened, edited, synchronize, labeled]
 
 jobs:
   check:
@@ -10,7 +10,8 @@ jobs:
     if: |
       !contains(github.event.pull_request.body, '[skip changelog]') &&
       !contains(github.event.pull_request.body, '[changelog skip]') &&
-      !contains(github.event.pull_request.body, '[skip ci]')
+      !contains(github.event.pull_request.body, '[skip ci]') &&
+      !contains(github.event.pull_request.labels.*.name, 'skip changelog')
     steps:
       - uses: actions/checkout@v1
       - name: Check that CHANGELOG is touched


### PR DESCRIPTION
Updates `check_changelog.yml` to support skipping the changelog check with a label named `skip changelog`. This spares us to edit descriptions and/or titles and allows us to easily filter for pull requests that skipped the changelog check.

In addition, this PR instructs Dependabot to add the `skip changelog` label to its PRs.

References [W-8239466](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008h0uIIAQ/view)