### PR TITLE
Add JVM_BUILDPACK_ASSETS_BASE_URL support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,8 @@
 version: 2.1
+parameters:
+  enable-hatchet-with-staging-bucket:
+    type: boolean
+    default: false
 
 orbs:
   heroku: circleci/heroku@1.1.1
@@ -23,13 +27,24 @@ jobs:
       heroku-stack:
         type: enum
         enum: ["cedar-14", "heroku-16", "heroku-18", "heroku-20"]
+      use-staging-bucket:
+        type: boolean
+        default: false
     docker:
       - image: circleci/ruby:2.7
     environment:
-      HEROKU_TEST_STACK: << parameters.heroku-stack >>
-      HATCHET_BUILDPACK_BASE: https://github.com/heroku/heroku-buildpack-jvm-common
       HATCHET_APP_LIMIT: 100
       PARALLEL_SPLIT_TEST_PROCESSES: 8
+      # We use the Java buildpack for all Hatchet tests and instruct it to use the code of the current branch as the
+      # source for the JVM common buildpack with the 'DEFAULT_APP_CONFIG_JVM_COMMON_BUILDPACK' environment
+      # variable.
+      HATCHET_BUILDPACK_BASE: https://github.com/heroku/heroku-buildpack-java
+      HATCHET_BUILDPACK_BRANCH: main
+      # Default stack for all Heroku apps created by Hatchet
+      DEFAULT_APP_STACK: << parameters.heroku-stack >>
+      # Default config variables for all Heroku apps created by Hatchet, prefixed with 'DEFAULT_APP_CONFIG_'
+      DEFAULT_APP_CONFIG_JVM_COMMON_BUILDPACK: "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/<< pipeline.git.branch >>"
+      DEFAULT_APP_CONFIG_JVM_BUILDPACK_ASSETS_BASE_URL: <<# parameters.use-staging-bucket >>https://lang-jvm-staging2.s3.amazonaws.com/<</ parameters.use-staging-bucket >>
     steps:
       - checkout
       - heroku/install
@@ -183,6 +198,14 @@ workflows:
             - shellcheck
           matrix:
             parameters:
+              heroku-stack: ["cedar-14", "heroku-16", "heroku-18", "heroku-20"]
+  hatchet-with-staging-bucket:
+    when: << pipeline.parameters.enable-hatchet-with-staging-bucket >>
+    jobs:
+      - hatchet:
+          matrix:
+            parameters:
+              use-staging-bucket: [true]
               heroku-stack: ["cedar-14", "heroku-16", "heroku-18", "heroku-20"]
   cnb-release-workflow:
     jobs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Main
 
+* Add support for JVM_BUILDPACK_ASSETS_BASE_URL environment variable (#179)
+* Deprecate support for JDK_BASE_URL environment variable (#179)
+
 ## v109
 
 * Add support for heroku-20 stack

--- a/bin/compile
+++ b/bin/compile
@@ -1,20 +1,27 @@
 #!/usr/bin/env bash
 
+# bin/compile <build-dir> <cache-dir> <env-dir>
+
 # fail fast
 set -e
 
 # parse args
-export BUILD_DIR=$1
+export BUILD_DIR="${1}"
+export CACHE_DIR="${2}"
+export ENV_DIR="${3}"
 
 BIN_DIR=$(
   cd "$(dirname "$0")"
   pwd
 ) # absolute path
 
-# shellcheck source=bin/java
-source "$BIN_DIR/java"
 # shellcheck source=bin/util
 source "$BIN_DIR/util"
+
+export_env_dir "${ENV_DIR}" "JVM_BUILDPACK_ASSETS_BASE_URL"
+
+# shellcheck source=bin/java
+source "$BIN_DIR/java"
 
 # Install JDK
 install_java_with_overlay "${BUILD_DIR}" "${CACHE_DIR}"

--- a/etc/trigger-ci-with-staging-bucket.sh
+++ b/etc/trigger-ci-with-staging-bucket.sh
@@ -15,11 +15,10 @@ EOF
 
 read -r -p "Do you want to continue? [y/N] " continue_response
 case "${continue_response}" in
-  [yY])
-    ;;
-  *)
-    exit 0
-    ;;
+[yY]) ;;
+*)
+  exit 0
+  ;;
 esac
 
 payload='{

--- a/etc/trigger-ci-with-staging-bucket.sh
+++ b/etc/trigger-ci-with-staging-bucket.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -o pipefail
+set -eu
+
+BRANCH="${1:-main}"
+
+echo "$(tput setaf 6)$(tput bold)[Trigger CI with Staging Bucket]$(tput sgr0)"
+cat <<EOF
+This will trigger a new CI run for branch $(tput setaf 6)$(tput bold)${BRANCH}$(tput sgr0), re-running all regular tests
+and also runs additional Hatchet tests while JVM_BUILDPACK_ASSETS_BASE_URL points to the staging bucket. This is useful
+for testing assets in the staging bucket before promoting them to production.
+
+EOF
+
+read -r -p "Do you want to continue? [y/N] " continue_response
+case "${continue_response}" in
+  [yY])
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+
+payload='{
+  "branch": "'${BRANCH}'",
+  "parameters": {
+    "enable-hatchet-with-staging-bucket": true
+  }
+}'
+
+curl \
+  -u "${CIRCLECI_TOKEN:?This script requires CIRCLECI_TOKEN environment variable to be set!}": \
+  --silent \
+  -X POST --header "Content-Type: application/json" -d "${payload:?}" \
+  https://circleci.com/api/v2/project/github/heroku/heroku-buildpack-jvm-common/pipeline

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -18,8 +18,15 @@ DEFAULT_JDK_13_VERSION="13.0.4"
 DEFAULT_JDK_14_VERSION="14.0.2"
 DEFAULT_JDK_15_VERSION="15.0.0"
 
-DEFAULT_JDK_BASE_URL="https://lang-jvm.s3.amazonaws.com/jdk/${STACK:-"heroku-18"}"
-JDK_BASE_URL=${JDK_BASE_URL:-$DEFAULT_JDK_BASE_URL}
+if [[ -n "${JDK_BASE_URL}" ]]; then
+  # Support for setting JDK_BASE_URL had the issue that it has to contain the stack name. This makes it hard to
+  # override the bucket for testing with staging binaries by using the existing JVM buildpack integration tests that
+  # cover all stacks. We will remove support for it in October 2021.
+  warning_inline "Support for the JDK_BASE_URL environment variable is deprecated and will be removed October 2021!"
+else
+  JVM_BUILDPACK_ASSETS_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL:-"https://lang-jvm.s3.amazonaws.com"}"
+  JDK_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL%/}/jdk/${STACK:-"heroku-18"}"
+fi
 
 get_jdk_version() {
   local appDir="${1:?}"

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -5,14 +5,7 @@ describe "Java" do
   ["1.7", "1.8", "8", "11", "13", "14", "15"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
-        Hatchet::Runner.new(
-          "java-servlets-sample",
-          buildpacks: ["https://github.com/heroku/heroku-buildpack-java"],
-          stack:  ENV["HEROKU_TEST_STACK"],
-          config: {
-            "JVM_COMMON_BUILDPACK" => "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}"
-          }
-        ).tap do |app|
+        new_default_hatchet_runner("java-servlets-sample").tap do |app|
           app.before_deploy do
             set_java_version(Dir.pwd, jdk_version)
           end
@@ -35,14 +28,7 @@ describe "Java" do
   context "a system.properties file with no java.runtime.version" do
     it "should deploy" do
       expected_version = "1.8"
-      Hatchet::Runner.new(
-        "java-servlets-sample",
-        buildpacks: ["https://github.com/heroku/heroku-buildpack-java"],
-        stack:  ENV["HEROKU_TEST_STACK"],
-        config: {
-          "JVM_COMMON_BUILDPACK" => "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}"
-        }
-      ).tap do |app|
+      new_default_hatchet_runner("java-servlets-sample").tap do |app|
         app.before_deploy do
           write_sys_props(Dir.pwd, "maven.version=3.3.9")
         end
@@ -58,14 +44,7 @@ describe "Java" do
   ["1.7", "1.8", "8", "11", "13", "14", "15"].each do |jdk_version|
     context "jdk-overlay on #{jdk_version}" do
       it "should deploy" do
-        Hatchet::Runner.new(
-          "java-overlay-test",
-          buildpacks: ["https://github.com/heroku/heroku-buildpack-java"],
-          stack:  ENV["HEROKU_TEST_STACK"],
-          config: {
-            "JVM_COMMON_BUILDPACK" => "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}"
-          }
-        ).tap do |app|
+        new_default_hatchet_runner("java-overlay-test").tap do |app|
           app.before_deploy do
             set_java_version(Dir.pwd, jdk_version)
           end
@@ -97,14 +76,7 @@ describe "Java" do
   ["1.8", "8", "11", "13", "14", "15"].each do |jdk_version|
     context "korvan on jdk-#{jdk_version}" do
       it "runs commands" do
-        Hatchet::Runner.new(
-          "korvan",
-          buildpacks: ["https://github.com/heroku/heroku-buildpack-java"],
-          stack:  ENV["HEROKU_TEST_STACK"],
-          config: {
-            "JVM_COMMON_BUILDPACK" => "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}"
-          }
-        ).tap do |app|
+        new_default_hatchet_runner("korvan").tap do |app|
           app.before_deploy do
             set_java_version(Dir.pwd, jdk_version)
           end

--- a/test/spec/metrics_spec.rb
+++ b/test/spec/metrics_spec.rb
@@ -4,15 +4,7 @@ describe "JVM Metrics" do
   ["1.7", "1.8", "11", "14", "15"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
-        Hatchet::Runner.new(
-          "java-servlets-sample",
-          labs: "runtime-heroku-metrics",
-          buildpacks: ["https://github.com/heroku/heroku-buildpack-java"],
-          stack:  ENV["HEROKU_TEST_STACK"],
-          config: {
-            "JVM_COMMON_BUILDPACK" => "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/#{jvm_common_branch}"
-          }
-        ).tap do |app|
+        new_default_hatchet_runner("java-servlets-sample", labs: "runtime-heroku-metrics").tap do |app|
           app.before_deploy do
             set_java_version(Dir.pwd, jdk_version)
           end

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -20,13 +20,17 @@ RSpec.configure do |config|
   end
 end
 
-def jvm_common_branch
-  return ENV['HATCHET_BUILDPACK_BRANCH'] if ENV['HATCHET_BUILDPACK_BRANCH']
-  return ENV['TRAVIS_PULL_REQUEST_BRANCH'] if ENV['TRAVIS_PULL_REQUEST_BRANCH'] && !ENV['TRAVIS_PULL_REQUEST_BRANCH'].empty?
-  return ENV['TRAVIS_BRANCH'] if ENV['TRAVIS_BRANCH']
-  return ENV['CIRCLE_BRANCH'] if ENV['CIRCLE_BRANCH']
+def new_default_hatchet_runner(*args, **kwargs)
+  kwargs[:stack] ||= ENV["DEFAULT_APP_STACK"]
+  kwargs[:config] ||= {}
 
-  raise 'Could not determine buildpack branch!'
+  ENV.keys.each do |key|
+    if key.start_with?("DEFAULT_APP_CONFIG_")
+      kwargs[:config][key.delete_prefix("DEFAULT_APP_CONFIG_")] ||= ENV[key]
+    end
+  end
+
+  Hatchet::Runner.new(*args, **kwargs)
 end
 
 def add_database(app, heroku)


### PR DESCRIPTION
Adds support for setting the base URL for assets used by the buildpack via the `JVM_BUILDPACK_ASSETS_BASE_URL` environment variable. Previously, a similar environment variable (`JDK_BASE_URL`) was available but had to contain the stack name, making it unwieldy to use. It has been deprecated.

In addition, the test suite has been updated to make use of that variable to allow testing against the staging bucket. The main use-case for this feature is testing binaries in the staging bucket before promoting them to production with the stock tests in this buildpack. Testing against the staging bucket can be triggered with the `./etc/trigger-ci-with-staging-bucket.sh` script.

Considerations:
- Even though`JDK_BASE_URL` was never exported with `export_env_dir`, the Java buildpack exports all environment variables before calling this buildpack, making it usable.

Closes [W-8256161](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008hCdlIAE/view)