### PR TITLE
Add heroku-20 stack to CNB buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -22,6 +22,9 @@ name = "JVM"
 [[stacks]]
 id = "heroku-18"
 
+[[stack]]
+id = "heroku-20"
+
 # this is to allow testing of other stack compatibility and is not a guarantee
 [[stacks]]
 id = "io.buildpacks.stacks.bionic"


### PR DESCRIPTION
Adds support for the `heroku/heroku:20` stack to the CNB implementation of this buildpack.