### PR TITLE
Upgrade CNB API to 0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* Upgrade CNB API compatibility version to 0.4
+
 ## v112
 
 * Upgrade default JDKs to 8u275 and 7u285

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,8 +1,8 @@
-api = "0.2"
+api = "0.4"
 
 [buildpack]
 id = "heroku/jvm"
-version = "0.1"
+version = "0.1.0"
 name = "JVM"
 
   [publish.Ignore]


### PR DESCRIPTION
This also updates the `version` in `buildpack.toml` to be valid semvar in prep for the Buildpack Regsitry.