### PR TITLE
Add Java 16 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* Add support for Java 16
+
 ## v117
 
 * Zulu Builds of OpenJDK for 15.0.2 are now available

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -90,7 +90,7 @@ get_jdk_url() {
   jdkVersion="$(get_full_jdk_version "${shortJdkVersion}")"
 
   local jdkUrl
-  if [ "$(expr "${jdkVersion}" : '^1[0-5]')" != 0 ]; then
+  if [ "$(expr "${jdkVersion}" : '^1[0-9]')" != 0 ]; then
     jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]')" != 0 ]; then
     jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -17,6 +17,7 @@ DEFAULT_JDK_12_VERSION="12.0.2"
 DEFAULT_JDK_13_VERSION="13.0.6"
 DEFAULT_JDK_14_VERSION="14.0.2"
 DEFAULT_JDK_15_VERSION="15.0.2"
+DEFAULT_JDK_16_VERSION="16.0.0"
 
 if [[ -n "${JDK_BASE_URL}" ]]; then
   # Support for setting JDK_BASE_URL had the issue that it has to contain the stack name. This makes it hard to
@@ -67,6 +68,8 @@ get_full_jdk_version() {
     echo "$DEFAULT_JDK_14_VERSION"
   elif [ "${jdkVersion}" = "15" ]; then
     echo "$DEFAULT_JDK_15_VERSION"
+  elif [ "${jdkVersion}" = "16" ]; then
+    echo "$DEFAULT_JDK_16_VERSION"
   elif [ "$(expr "${jdkVersion}" : '^1.[6-9]$')" != 0 ]; then
     local minorJdkVersion
     minorJdkVersion=$(expr "${jdkVersion}" : '1.\([6-9]\)')

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 describe "Java" do
 
-  ["1.7", "1.8", "8", "11", "13", "14", "15"].each do |jdk_version|
+  ["1.7", "1.8", "8", "11", "13", "15", "16"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
         new_default_hatchet_runner("java-servlets-sample").tap do |app|
@@ -41,7 +41,7 @@ describe "Java" do
     end
   end
 
-  ["1.7", "1.8", "8", "11", "13", "14", "15"].each do |jdk_version|
+  ["1.7", "1.8", "8", "11", "13", "15", "16"].each do |jdk_version|
     context "jdk-overlay on #{jdk_version}" do
       it "should deploy" do
         new_default_hatchet_runner("java-overlay-test").tap do |app|
@@ -73,7 +73,7 @@ describe "Java" do
     end
   end
 
-  ["1.8", "8", "11", "13", "14", "15"].each do |jdk_version|
+  ["1.8", "8", "11", "13", "15", "16"].each do |jdk_version|
     context "korvan on jdk-#{jdk_version}" do
       it "runs commands" do
         new_default_hatchet_runner("korvan").tap do |app|

--- a/test/spec/metrics_spec.rb
+++ b/test/spec/metrics_spec.rb
@@ -1,7 +1,7 @@
 require_relative 'spec_helper'
 
 describe "JVM Metrics" do
-  ["1.7", "1.8", "11", "14", "15"].each do |jdk_version|
+  ["1.7", "1.8", "11", "15", "16"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
         new_default_hatchet_runner("java-servlets-sample", labs: "runtime-heroku-metrics").tap do |app|


### PR DESCRIPTION
Adds support for OpenJDK 16. Tests are expected to fail at first since the binaries are not available in production. Staging tests will run before promoting binaries to production.

References [W-8655912](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008vpf0IAA/view)