### PR TITLE
Update default version of OpenJDK 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Main
 
+## v124
+* Upgrade default JDKs to 17.0.1
+
 ## v123
 * Upgrade default JDKs to 15.0.5, 13.0.9, 11.0.13, and 8u312 
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -18,7 +18,7 @@ DEFAULT_JDK_13_VERSION="13.0.9"
 DEFAULT_JDK_14_VERSION="14.0.2"
 DEFAULT_JDK_15_VERSION="15.0.5"
 DEFAULT_JDK_16_VERSION="16.0.2"
-DEFAULT_JDK_17_VERSION="17.0.0"
+DEFAULT_JDK_17_VERSION="17.0.1"
 
 if [[ -n "${JDK_BASE_URL}" ]]; then
   # Support for setting JDK_BASE_URL had the issue that it has to contain the stack name. This makes it hard to


### PR DESCRIPTION
OpenJDK releases for the third quarter of 2021

References:
[W-10084724](https://gus.my.salesforce.com/one/one.app#/alohaRedirect/a07EE00000JMShPYAX)