### PR TITLE
Heroku-22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,13 +14,16 @@ executors:
   heroku-20:
     docker:
       - image: heroku/heroku:20
+  heroku-22:
+    docker:
+      - image: heroku/heroku:22
 
 jobs:
   hatchet:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20", "heroku-22"]
       use-staging-bucket:
         type: boolean
         default: false
@@ -83,7 +86,7 @@ jobs:
     parameters:
       heroku-stack:
         type: enum
-        enum: ["heroku-18", "heroku-20"]
+        enum: ["heroku-18", "heroku-20", "heroku-22"]
     environment:
       STACK: << parameters.heroku-stack >>
     executor:
@@ -133,7 +136,7 @@ workflows:
             - shellcheck
           matrix:
             parameters:
-              heroku-stack: ["heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20", "heroku-22"]
 
       - buildpack-testrunner:
           requires:
@@ -146,7 +149,7 @@ workflows:
             - shellcheck
           matrix:
             parameters:
-              heroku-stack: ["heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20", "heroku-22"]
   hatchet-with-staging-bucket:
     when: << pipeline.parameters.enable-hatchet-with-staging-bucket >>
     jobs:
@@ -154,4 +157,4 @@ workflows:
           matrix:
             parameters:
               use-staging-bucket: [true]
-              heroku-stack: ["heroku-18", "heroku-20"]
+              heroku-stack: ["heroku-18", "heroku-20", "heroku-22"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Main
 
-* Refactor OpenJDK version resolution code.
-* Drop support for OpenJDK 9 and OpenJDK 12, both versions are not available on any supported stack.
-* Add support for `heroku-22` stack.
+* Refactor OpenJDK version resolution code. ([#237](https://github.com/heroku/heroku-buildpack-jvm-common/pull/237))
+* Drop support for OpenJDK `9` and OpenJDK `12`, both versions are not available on any supported stack. ([#237](https://github.com/heroku/heroku-buildpack-jvm-common/pull/237))
+* Add support for `heroku-22` stack. ([#236](https://github.com/heroku/heroku-buildpack-jvm-common/pull/236))
+* Change default OpenJDK distribution to [Azul Zulu Builds of OpenJDK](https://www.azul.com/downloads/?package=jdk#download-openjdk) on stacks >= `heroku-22`. ([#236](https://github.com/heroku/heroku-buildpack-jvm-common/pull/236))
 
 ## v131
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Refactor OpenJDK version resolution code.
 * Drop support for OpenJDK 9 and OpenJDK 12, both versions are not available on any supported stack.
+* Add support for `heroku-22` stack.
 
 ## v131
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -61,7 +61,13 @@ get_jdk_url() {
   case ${jdkVersion} in
   openjdk-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion//openjdk-/openjdk}.tar.gz" ;;
   zulu-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion}.tar.gz" ;;
-  *) jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz" ;;
+  *)
+    if [ "${STACK}" == "heroku-18" ] || [ "${STACK}" == "heroku-20" ]; then
+      jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
+    else
+      jdkUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"
+    fi
+    ;;
   esac
 
   echo "${jdkUrl}"

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -53,38 +53,14 @@ testCompileWith_openjdk_1_8_0_144() {
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
 
-testCompileWith_9_0_1() {
-  echo "java.runtime.version=9.0.1" >"${BUILD_DIR}/system.properties"
+testCompileWith_zulu_11_0_15() {
+  echo "java.runtime.version=zulu-11.0.15" >"${BUILD_DIR}/system.properties"
 
   compile
 
   assertCapturedSuccess
 
-  assertCaptured "Installing JDK 9.0.1"
-  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
-  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
-}
-
-testCompileWith_zulu_9_0_0() {
-  echo "java.runtime.version=zulu-11.0.4" >"${BUILD_DIR}/system.properties"
-
-  compile
-
-  assertCapturedSuccess
-
-  assertCaptured "Installing Azul Zulu JDK 11.0.4"
-  assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
-  assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
-}
-
-testCompileWith_10() {
-  echo "java.runtime.version=10" >"${BUILD_DIR}/system.properties"
-
-  compile
-
-  assertCapturedSuccess
-
-  assertCaptured "Installing JDK 10"
+  assertCaptured "Installing Azul Zulu JDK 11.0.15"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }

--- a/test/v2
+++ b/test/v2
@@ -237,24 +237,45 @@ test_install_jdk_invalid() {
 }
 
 test_get_jdk_url_with_default() {
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+  if [ "${STACK}" == "heroku-18" ] || [ "${STACK}" == "heroku-20" ]; then
+    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
 
-  export JDK_URL_1_8="https://example.com/java8"
-  assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_332")"
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.7.0_272.tar.gz" "$(_get_jdk_url_with_default "1.7.0_272")"
-  assertEquals "${JDK_BASE_URL:?}/openjdk11.0.8.tar.gz" "$(_get_jdk_url_with_default "11.0.8")"
-  assertEquals "${JDK_BASE_URL:?}/zulu-11.0.8.tar.gz" "$(_get_jdk_url_with_default "zulu-11.0.8")"
-  unset JDK_URL_1_8
+    export JDK_URL_1_8="https://example.com/java8"
+    assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk1.7.0_272.tar.gz" "$(_get_jdk_url_with_default "1.7.0_272")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk11.0.8.tar.gz" "$(_get_jdk_url_with_default "11.0.8")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-11.0.8.tar.gz" "$(_get_jdk_url_with_default "zulu-11.0.8")"
+    unset JDK_URL_1_8
 
-  export JDK_URL_1_7="https://example.com/java7"
-  assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_272")"
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
-  unset JDK_URL_1_7
+    export JDK_URL_1_7="https://example.com/java7"
+    assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_272")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    unset JDK_URL_1_7
 
-  export JDK_URL_11="https://example.com/java11"
-  assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.8")"
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
-  unset JDK_URL_11
+    export JDK_URL_11="https://example.com/java11"
+    assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.8")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    unset JDK_URL_11
+  else
+    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+
+    export JDK_URL_1_8="https://example.com/java8"
+    assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-1.7.0_272.tar.gz" "$(_get_jdk_url_with_default "1.7.0_272")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-11.0.8.tar.gz" "$(_get_jdk_url_with_default "11.0.8")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk11.0.8.tar.gz" "$(_get_jdk_url_with_default "openjdk-11.0.8")"
+    unset JDK_URL_1_8
+
+    export JDK_URL_1_7="https://example.com/java7"
+    assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_272")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    unset JDK_URL_1_7
+
+    export JDK_URL_11="https://example.com/java11"
+    assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.8")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    unset JDK_URL_11
+  fi
 }
 
 # the modules to be tested

--- a/test/v2
+++ b/test/v2
@@ -130,13 +130,13 @@ test_installJavaCI() {
 
 test_installJavaWithVersion() {
   unset JAVA_HOME # unsets environment -- shunit doesn't clean environment before each test
-  capture install_java "${BUILD_DIR}" "1.8.0_265"
+  capture install_java "${BUILD_DIR}" "1.8.0_332"
   assertTrue "A .jdk directory should be created when installing java." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "The java runtime should be present." "[ -f ${BUILD_DIR}/.jdk/bin/java ]"
   assertEquals "${BUILD_DIR}/.jdk" "${JAVA_HOME}"
   assertContains "${PATH}" "${BUILD_DIR}/.jdk/bin"
   assertTrue "A version file should have been created." "[ -f ${BUILD_DIR}/.jdk/version ]"
-  assertEquals "$(cat "${BUILD_DIR}/.jdk/version")" "1.8.0_265"
+  assertEquals "$(cat "${BUILD_DIR}/.jdk/version")" "1.8.0_332"
   assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
   assertTrue "A profile.d file should have been created." "[ -f ${BUILD_DIR}/.profile.d/jvmcommon.sh ]"
 }
@@ -194,17 +194,17 @@ test_invalidJdkURL() {
 }
 
 test_customJdk() {
-  capture install_java "${BUILD_DIR}" "1.8.0_265"
+  capture install_java "${BUILD_DIR}" "1.8.0_332"
   assertCapturedSuccess
 }
 
 test_zuluJdk() {
-  capture install_java "${BUILD_DIR}" "zulu-1.8.0_265"
+  capture install_java "${BUILD_DIR}" "zulu-1.8.0_332"
   assertCapturedSuccess
 }
 
 test_openJdk() {
-  capture install_java "${BUILD_DIR}" "openjdk-1.8.0_265"
+  capture install_java "${BUILD_DIR}" "openjdk-1.8.0_332"
   assertCapturedSuccess
 }
 
@@ -237,10 +237,10 @@ test_install_jdk_invalid() {
 }
 
 test_get_jdk_url_with_default() {
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_265.tar.gz" "$(_get_jdk_url_with_default "1.8.0_265")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
 
   export JDK_URL_1_8="https://example.com/java8"
-  assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_265")"
+  assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_332")"
   assertEquals "${JDK_BASE_URL:?}/openjdk1.7.0_272.tar.gz" "$(_get_jdk_url_with_default "1.7.0_272")"
   assertEquals "${JDK_BASE_URL:?}/openjdk11.0.8.tar.gz" "$(_get_jdk_url_with_default "11.0.8")"
   assertEquals "${JDK_BASE_URL:?}/zulu-11.0.8.tar.gz" "$(_get_jdk_url_with_default "zulu-11.0.8")"
@@ -248,12 +248,12 @@ test_get_jdk_url_with_default() {
 
   export JDK_URL_1_7="https://example.com/java7"
   assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_272")"
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_265.tar.gz" "$(_get_jdk_url_with_default "1.8.0_265")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
   unset JDK_URL_1_7
 
   export JDK_URL_11="https://example.com/java11"
   assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.8")"
-  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_265.tar.gz" "$(_get_jdk_url_with_default "1.8.0_265")"
+  assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
   unset JDK_URL_11
 }
 


### PR DESCRIPTION
Adds support for the `heroku-22` stack. Binaries have already been built, and the existing code would work just fine on `heroku-22`. Therefore this PR mainly updates tests and CI for the new stack.

Another big change is the switch to Azul Zulu as the default OpenJDK distribution on the new stack.

References GUS-W-10343931
Closes GUS-W-11200793