### PR TITLE
Add support for distribution prefixes with non-patch release versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Main
 
+## v133
+
+* Allow OpenJDK distribution prefixes to be used in conjunction with major versions. Previously, a specific patch version was required when using a distribution prefix. ([#239](https://github.com/heroku/heroku-buildpack-jvm-common/pull/239)) 
+
 ## v132
 
 * Refactor OpenJDK version resolution code. ([#237](https://github.com/heroku/heroku-buildpack-jvm-common/pull/237))

--- a/bin/java
+++ b/bin/java
@@ -22,13 +22,16 @@ install_java_with_overlay() {
 
     _jvm_mcount "version.${jdkVersion}"
     if [[ "$jdkVersion" == *openjdk* ]]; then
-      status_pending "Installing OpenJDK $(_get_openjdk_version "${jdkVersion}")"
+      status_pending "Installing Heroku OpenJDK $(_get_openjdk_version "${jdkVersion}")"
+      _jvm_mcount "vendor.openjdk"
+    elif [[ "$jdkVersion" == *heroku* ]]; then
+      status_pending "Installing Heroku OpenJDK $(_get_heroku_version "${jdkVersion}")"
       _jvm_mcount "vendor.openjdk"
     elif [[ "$jdkVersion" == *zulu* ]]; then
-      status_pending "Installing Azul Zulu JDK $(_get_zulu_version "${jdkVersion}")"
+      status_pending "Installing Azul Zulu OpenJDK $(_get_zulu_version "${jdkVersion}")"
       _jvm_mcount "vendor.zulu"
     else
-      status_pending "Installing JDK ${jdkVersion}"
+      status_pending "Installing OpenJDK ${jdkVersion}"
       _jvm_mcount "vendor.default"
     fi
     install_java "${buildDir}" "${jdkVersion}" "${jdkUrl}"
@@ -203,6 +206,10 @@ _get_zulu_version() {
 
 _get_openjdk_version() {
   echo "${1//openjdk-/}"
+}
+
+_get_heroku_version() {
+  echo "${1//heroku-/}"
 }
 
 _get_url_status() {

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -37,11 +37,24 @@ get_jdk_version() {
 }
 
 get_full_jdk_version() {
-  local jdkVersion="${1:?}"
+  # The version argument can potentially have a prefix which denotes the
+  # OpenJDK distribution. This function only normalizes the actual version
+  # and keeps the prefix intact.
+  IFS='-' read -r prefix version <<<"${1:?}"
 
-  case "${jdkVersion}" in
+  if [ -z "${version}" ]; then
+    # If the version variable is empty, there is no prefix and the
+    # version was stored in the prefix variable.
+    version="${prefix}"
+  else
+    # When there is a prefix, emit it before emitting the normalized
+    # version to keep it untouched by this function.
+    echo -n "${prefix}-"
+  fi
+
+  case "${version}" in
   "7" | "1.7") echo "${DEFAULT_JDK_1_7_VERSION}" ;;
-  "8" | "1.8") echo "{$DEFAULT_JDK_1_8_VERSION}" ;;
+  "8" | "1.8") echo "${DEFAULT_JDK_1_8_VERSION}" ;;
   "10") echo "${DEFAULT_JDK_10_VERSION}" ;;
   "11") echo "${DEFAULT_JDK_11_VERSION}" ;;
   "13") echo "${DEFAULT_JDK_13_VERSION}" ;;
@@ -50,7 +63,7 @@ get_full_jdk_version() {
   "16") echo "${DEFAULT_JDK_16_VERSION}" ;;
   "17") echo "${DEFAULT_JDK_17_VERSION}" ;;
   "18") echo "${DEFAULT_JDK_18_VERSION}" ;;
-  *) echo "${jdkVersion}" ;;
+  *) echo "${version}" ;;
   esac
 }
 
@@ -59,6 +72,7 @@ get_jdk_url() {
   jdkVersion="$(get_full_jdk_version "${1:-${DEFAULT_JDK_VERSION}}")"
 
   case ${jdkVersion} in
+  heroku-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion//heroku-/openjdk}.tar.gz" ;;
   openjdk-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion//openjdk-/openjdk}.tar.gz" ;;
   zulu-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion}.tar.gz" ;;
   *)

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -12,7 +12,7 @@ testCompileWithoutSystemProperties() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing JDK 1.8"
+  assertCaptured "Installing OpenJDK 1.8"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
@@ -24,7 +24,7 @@ testCompileWith_1_8_0_144() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing JDK 1.8.0_144"
+  assertCaptured "Installing OpenJDK 1.8.0_144"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
@@ -36,7 +36,7 @@ testCompileWith_zulu_1_8_0_144() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing Azul Zulu JDK 1.8.0_144"
+  assertCaptured "Installing Azul Zulu OpenJDK 1.8.0_144"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
@@ -48,7 +48,7 @@ testCompileWith_openjdk_1_8_0_144() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing OpenJDK 1.8.0_144"
+  assertCaptured "Installing Heroku OpenJDK 1.8.0_144"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
@@ -60,7 +60,7 @@ testCompileWith_zulu_11_0_15() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing Azul Zulu JDK 11.0.15"
+  assertCaptured "Installing Azul Zulu OpenJDK 11.0.15"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 describe "Java" do
 
-  ["1.7", "1.8", "8", "11", "13", "15", "16", "17", "18", "11.0.15", "openjdk-11.0.15", "zulu-11.0.15"].each do |jdk_version|
+  ["1.7", "1.8", "8", "11", "13", "15", "16", "17", "18", "11.0.15", "openjdk-11.0.15", "zulu-11.0.15", "heroku-17", "zulu-17"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
         new_default_hatchet_runner("java-servlets-sample").tap do |app|

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -11,11 +11,13 @@ describe "Java" do
           end
           app.deploy do
             if jdk_version.start_with?("zulu")
-              expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
+              expect(app.output).to include("Installing Azul Zulu OpenJDK #{jdk_version.gsub('zulu-', '')}")
             elsif jdk_version.start_with?("openjdk")
-              expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
+              expect(app.output).to include("Installing Heroku OpenJDK #{jdk_version.gsub('openjdk-', '')}")
+            elsif jdk_version.start_with?("heroku")
+              expect(app.output).to include("Installing Heroku OpenJDK #{jdk_version.gsub('heroku-', '')}")
             else
-              expect(app.output).to include("Installing JDK #{jdk_version}")
+              expect(app.output).to include("Installing OpenJDK #{jdk_version}")
             end
             expect(app.output).to include("BUILD SUCCESS")
             expect(successful_body(app)).to eq("Hello from Java!")
@@ -33,7 +35,7 @@ describe "Java" do
           write_sys_props(Dir.pwd, "maven.version=3.3.9")
         end
         app.deploy do
-          expect(app.output).to include("Installing JDK #{expected_version}")
+          expect(app.output).to include("Installing OpenJDK #{expected_version}")
           expect(app.output).to include("BUILD SUCCESS")
           expect(successful_body(app)).to eq("Hello from Java!")
         end
@@ -50,11 +52,13 @@ describe "Java" do
           end
           app.deploy do
             if jdk_version.start_with?("zulu")
-              expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
+              expect(app.output).to include("Installing Azul Zulu OpenJDK #{jdk_version.gsub('zulu-', '')}")
             elsif jdk_version.start_with?("openjdk")
-              expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
+              expect(app.output).to include("Installing Heroku OpenJDK #{jdk_version.gsub('openjdk-', '')}")
+            elsif jdk_version.start_with?("heroku")
+              expect(app.output).to include("Installing Heroku OpenJDK #{jdk_version.gsub('heroku-', '')}")
             else
-              expect(app.output).to include("Installing JDK #{jdk_version}")
+              expect(app.output).to include("Installing OpenJDK #{jdk_version}")
             end
             expect(app.output).to include("BUILD SUCCESS")
 
@@ -82,11 +86,13 @@ describe "Java" do
           end
           app.deploy do |app|
             if jdk_version.start_with?("zulu")
-              expect(app.output).to include("Installing Azul Zulu JDK #{jdk_version.gsub('zulu-', '')}")
+              expect(app.output).to include("Installing Azul Zulu OpenJDK #{jdk_version.gsub('zulu-', '')}")
             elsif jdk_version.start_with?("openjdk")
-              expect(app.output).to include("Installing OpenJDK #{jdk_version.gsub('openjdk-', '')}")
+              expect(app.output).to include("Installing Heroku OpenJDK #{jdk_version.gsub('openjdk-', '')}")
+            elsif jdk_version.start_with?("heroku")
+              expect(app.output).to include("Installing Heroku OpenJDK #{jdk_version.gsub('heroku-', '')}")
             else
-              expect(app.output).to include("Installing JDK #{jdk_version}")
+              expect(app.output).to include("Installing OpenJDK #{jdk_version}")
             end
 
             sleep 1


### PR DESCRIPTION
Allow OpenJDK distribution prefixes to be used in conjunction with major versions. Previously, a specific patch version was required when using a distribution prefix. In addition, an alias prefix for `openjdk` was introduced: `heroku`. The new prefix makes it more clear that it will select a build of OpenJDK that was built by Heroku.

For example, previously unsupported version strings such as `zulu-11`, `openjdk-17` or `heroku-8` are now supported and will resolve to the latest patch release of the specified major version.

The `CHANGELOG` was updated for immediate release as `v133`.

- Fixes #224 
- Closes GUS-W-11264756