### PR TITLE
Switch to the recommended regional S3 domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       DEFAULT_APP_STACK: << parameters.heroku-stack >>
       # Default config variables for all Heroku apps created by Hatchet, prefixed with 'DEFAULT_APP_CONFIG_'
       DEFAULT_APP_CONFIG_JVM_COMMON_BUILDPACK: "https://api.github.com/repos/heroku/heroku-buildpack-jvm-common/tarball/<< pipeline.git.branch >>"
-      DEFAULT_APP_CONFIG_JVM_BUILDPACK_ASSETS_BASE_URL: <<# parameters.use-staging-bucket >>https://lang-jvm-staging2.s3.amazonaws.com/<</ parameters.use-staging-bucket >>
+      DEFAULT_APP_CONFIG_JVM_BUILDPACK_ASSETS_BASE_URL: <<# parameters.use-staging-bucket >>https://lang-jvm-staging2.s3.us-east-1.amazonaws.com/<</ parameters.use-staging-bucket >>
     steps:
       - checkout
       - heroku/install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* Switch to the recommended regional S3 domain instead of the global one. ([#240](https://github.com/heroku/heroku-buildpack-jvm-common/pull/240))
+
 ## v133
 
 * Allow OpenJDK distribution prefixes to be used in conjunction with major versions. Previously, a specific patch version was required when using a distribution prefix. ([#239](https://github.com/heroku/heroku-buildpack-jvm-common/pull/239)) 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the official [Heroku buildpack](https://devcenter.heroku.com/articles/bu
 This is how the buildpack is used from another buildpack:
 
 ```bash
-JVM_BUILDPACK_URL="https://buildpack-registry.s3.amazonaws.com/buildpacks/heroku/jvm.tgz"
+JVM_BUILDPACK_URL="https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz"
 mkdir -p /tmp/jvm-common
 curl --silent --location $JVM_BUILDPACK_URL | tar xzm -C /tmp/jvm-common --strip-components=1
 source /tmp/jvm-common/bin/util

--- a/bin/java
+++ b/bin/java
@@ -172,7 +172,7 @@ _install_pgconfig() {
   local extDir="${javaHome}/jre/lib/ext"
 
   if [ -d "${extDir}" ] && [ -z "${SKIP_PGCONFIG_INSTALL:-}" ] && [ "${CI:-}" != "true" ]; then
-    curl --retry 3 -s -L "https://lang-jvm.s3.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
+    curl --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
   fi
 }
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -18,7 +18,7 @@ if [[ -n "${JDK_BASE_URL}" ]]; then
   # cover all stacks. We will remove support for it in October 2021.
   warning_inline "Support for the JDK_BASE_URL environment variable is deprecated and will be removed October 2021!"
 else
-  JVM_BUILDPACK_ASSETS_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL:-"https://lang-jvm.s3.amazonaws.com"}"
+  JVM_BUILDPACK_ASSETS_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL:-"https://lang-jvm.s3.us-east-1.amazonaws.com"}"
   JDK_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL%/}/jdk/${STACK:-"heroku-18"}"
 fi
 


### PR DESCRIPTION
Whilst the global S3 endpoint (`s3.amazonaws.com`) still works, AWS now recommends using the appropriate regional endpoint to access the bucket:
https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#s3-legacy-endpoints

Our buildpack buckets are in `us-east-1`, whose regional domain is `*.s3.us-east-1.amazonaws.com`:
https://docs.aws.amazon.com/general/latest/gr/s3.html#s3_region

GUS-W-11283397.