### PR TITLE
Adjust curl retry and connection timeout handling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,7 +74,7 @@ jobs:
             sudo apt-get install file
       - run:
           name: Download and unpack shunit 2.1.6
-          command: curl -sSf https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
+          command: curl -sSf --retry 3 --retry-connrefused --connect-timeout 5 https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
       - run:
           name: Clone heroku-buildpack-testrunner
           command: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Main
 
+* Adjust curl retry and connection timeout handling. ([#241](https://github.com/heroku/heroku-buildpack-jvm-common/pull/241))
 * Switch to the recommended regional S3 domain instead of the global one. ([#240](https://github.com/heroku/heroku-buildpack-jvm-common/pull/240))
 
 ## v133

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is how the buildpack is used from another buildpack:
 ```bash
 JVM_BUILDPACK_URL="https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz"
 mkdir -p /tmp/jvm-common
-curl --silent --location $JVM_BUILDPACK_URL | tar xzm -C /tmp/jvm-common --strip-components=1
+curl --silent --fail --retry 3 --retry-connrefused --connect-timeout 5 --location $JVM_BUILDPACK_URL | tar xzm -C /tmp/jvm-common --strip-components=1
 source /tmp/jvm-common/bin/util
 source /tmp/jvm-common/bin/java
 

--- a/bin/java
+++ b/bin/java
@@ -172,7 +172,7 @@ _install_pgconfig() {
   local extDir="${javaHome}/jre/lib/ext"
 
   if [ -d "${extDir}" ] && [ -z "${SKIP_PGCONFIG_INSTALL:-}" ] && [ "${CI:-}" != "true" ]; then
-    curl --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
+    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
   fi
 }
 
@@ -213,7 +213,7 @@ _get_heroku_version() {
 }
 
 _get_url_status() {
-  curl --retry 3 --silent --head -w "%{http_code}" -L "${1}" -o /dev/null
+  curl --retry 3 --retry-connrefused --connect-timeout 5 --silent --head -w "%{http_code}" -L "${1}" -o /dev/null
 }
 
 _jvm_mcount() {

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -94,12 +94,12 @@ install_jdk() {
   local key="${4:-${bpDir}/.gnupg/lang-jvm.asc}"
   local tarball="/tmp/jdk.tgz"
 
-  curl --retry 3 --silent --show-error --location "${url}" --output "${tarball}"
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --show-error --location "${url}" --output "${tarball}"
 
   if [ "${HEROKU_GPG_VALIDATION:-0}" != "1" ]; then
     _jvm_mcount "gpg.verify.skip"
   else
-    curl --retry 3 --silent --show-error --location "${url}.gpg" --output "${tarball}.gpg"
+    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --show-error --location "${url}.gpg" --output "${tarball}.gpg"
 
     gpg --no-tty --batch --import "${key}" >/dev/null 2>&1
 
@@ -160,7 +160,7 @@ install_metrics_agent() {
   local agentJar="${installDir}/heroku-metrics-agent.jar"
 
   mkdir -p "${installDir}"
-  curl --retry 3 -s -o "${agentJar}" \
+  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 -s -o "${agentJar}" \
     -L "${HEROKU_METRICS_JAR_URL:-"https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.14/heroku-java-metrics-agent-3.14.jar"}"
   if [ -f "${agentJar}" ]; then
     mkdir -p "${profileDir}"

--- a/test/v2
+++ b/test/v2
@@ -229,7 +229,7 @@ test_install_jdk_invalid() {
   local key
   key="$(mktemp)"
 
-  curl -sf -o "${key}" -L "https://www.php.net/distributions/php-keyring.gpg"
+  curl -sf --retry 3 --retry-connrefused --connect-timeout 5 -o "${key}" -L "https://www.php.net/distributions/php-keyring.gpg"
   export HEROKU_GPG_VALIDATION=1
   capture install_jdk "${JDK_BASE_URL}/openjdk11.0.8.tar.gz" "$(mktemp -d)" "${BUILDPACK_HOME}" "${key}"
   assertCapturedError " !     ERROR: Invalid GPG signature!"


### PR DESCRIPTION
In the shimmed CNBs used in `heroku/builder` we have been seeing quite a few transient errors related to buildpacks downloading from S3.

Adding appropriate retries and connection timeouts to all of our buildpack's curl usages should help with these, as well as make builds more reliable in general for users on Heroku, plus also anyone using a shimmed CNB locally with Pack CLI (where the network connection may be even less reliable).

The `--retry-connrefused` option has been used since otherwise curl doesn't retry cases where the connection was refused. Ideally we would use `--retry-all-errors` which takes that one step further, however that option was only added in curl 7.71, so is only supported by Heroku-22+.

For more on curl options, see:
https://curl.se/docs/manpage.html

GUS-W-11283397.