### PR TITLE
Only use `--retry-connrefused` on Ubuntu based stacks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
 
   buildpack-testrunner:
     docker:
-      - image: circleci/openjdk:8
+      - image: cimg/openjdk:8.0
     environment:
       SHUNIT_HOME: /tmp/shunit2-2.1.6
       # Note the missing STACK environment variable here. This works since there is a default value in the buildpack
@@ -78,6 +78,26 @@ jobs:
       - run:
           name: Clone heroku-buildpack-testrunner
           command: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner
+      - run:
+          name: Apply heroku-buildpack-testrunner patches to enforce bash shell
+          command: |
+            cd /tmp/testrunner
+            git apply \<<'EOF'
+            diff --git a/bin/run b/bin/run
+            index 0d5b790..a0ff25c 100755
+            --- a/bin/run
+            +++ b/bin/run
+            @@ -101,7 +101,7 @@ for bp in ${@}; do
+                 suite_start_time="$(date +%s)"
+             
+                 echo "  TEST SUITE: $(basename ${f})"
+            -    ${SHUNIT_HOME?"'SHUNIT_HOME' environment variable must be set"}/src/shunit2 ${f} | indent
+            +    /bin/bash ${SHUNIT_HOME?"'SHUNIT_HOME' environment variable must be set"}/src/shunit2 ${f} | indent
+                 exit_code=$(max ${exit_code} ${PIPESTATUS[0]})
+             
+                 suite_end_time="$(date +%s)"
+
+            EOF
       - run:
           name: Execute buildpack-testrunner
           command: /tmp/testrunner/bin/run .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Main
 
+## v135
+
+* Only use `--retry-connrefused` on Ubuntu based stacks. ([#243](https://github.com/heroku/heroku-buildpack-jvm-common/pull/243))
+
 ## v134
 
 * Adjust curl retry and connection timeout handling. ([#241](https://github.com/heroku/heroku-buildpack-jvm-common/pull/241))

--- a/bin/java
+++ b/bin/java
@@ -172,7 +172,7 @@ _install_pgconfig() {
   local extDir="${javaHome}/jre/lib/ext"
 
   if [ -d "${extDir}" ] && [ -z "${SKIP_PGCONFIG_INSTALL:-}" ] && [ "${CI:-}" != "true" ]; then
-    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
+    curl_with_defaults --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
   fi
 }
 
@@ -213,7 +213,7 @@ _get_heroku_version() {
 }
 
 _get_url_status() {
-  curl --retry 3 --retry-connrefused --connect-timeout 5 --silent --head -w "%{http_code}" -L "${1}" -o /dev/null
+  curl_with_defaults --retry 3 --silent --head -w "%{http_code}" -L "${1}" -o /dev/null
 }
 
 _jvm_mcount() {

--- a/bin/util
+++ b/bin/util
@@ -96,3 +96,15 @@ copy_directories() {
     fi
   done
 }
+
+curl_with_defaults() {
+  default_args=()
+
+  # Some company-internal users are building their slugs on CentOS where these newer curl commands aren't
+  # supported yet. This conditional ensures their builds continue to work.
+  if uname -a | grep -q Ubuntu; then
+    default_args+=("--retry-connrefused" "--connect-timeout" "5")
+  fi
+
+  curl "${default_args[@]}" "${@}"
+}

--- a/bin/util
+++ b/bin/util
@@ -102,7 +102,7 @@ curl_with_defaults() {
 
   # Some company-internal users are building their slugs on CentOS where these newer curl commands aren't
   # supported yet. This conditional ensures their builds continue to work.
-  if uname -a | grep -q Ubuntu; then
+  if curl --help all | grep -q -- --retry-connrefused; then
     default_args+=("--retry-connrefused" "--connect-timeout" "5")
   fi
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -94,12 +94,12 @@ install_jdk() {
   local key="${4:-${bpDir}/.gnupg/lang-jvm.asc}"
   local tarball="/tmp/jdk.tgz"
 
-  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --show-error --location "${url}" --output "${tarball}"
+  curl_with_defaults --retry 3 --silent --show-error --location "${url}" --output "${tarball}"
 
   if [ "${HEROKU_GPG_VALIDATION:-0}" != "1" ]; then
     _jvm_mcount "gpg.verify.skip"
   else
-    curl --fail --retry 3 --retry-connrefused --connect-timeout 5 --silent --show-error --location "${url}.gpg" --output "${tarball}.gpg"
+    curl_with_defaults --fail --silent --show-error --location "${url}.gpg" --output "${tarball}.gpg"
 
     gpg --no-tty --batch --import "${key}" >/dev/null 2>&1
 
@@ -160,7 +160,7 @@ install_metrics_agent() {
   local agentJar="${installDir}/heroku-metrics-agent.jar"
 
   mkdir -p "${installDir}"
-  curl --fail --retry 3 --retry-connrefused --connect-timeout 5 -s -o "${agentJar}" \
+  curl_with_defaults --retry 3 -s -o "${agentJar}" \
     -L "${HEROKU_METRICS_JAR_URL:-"https://repo1.maven.org/maven2/com/heroku/agent/heroku-java-metrics-agent/3.14/heroku-java-metrics-agent-3.14.jar"}"
   if [ -f "${agentJar}" ]; then
     mkdir -p "${profileDir}"

--- a/test/v2
+++ b/test/v2
@@ -279,6 +279,9 @@ test_get_jdk_url_with_default() {
 }
 
 # the modules to be tested
+# shellcheck source=bin/util
+source "${BUILDPACK_HOME}/bin/util"
+
 # shellcheck source=bin/java
 source "${BUILDPACK_HOME}/bin/java"
 


### PR DESCRIPTION
Some internal users use this buildpack on nonstandard stacks where `--retry-connrefused` is not a supported `curl` flag. To unblock these users, the mentioned `curl` flag will now only be used on Ubuntu based stacks as a workaround.

Changelog was updated for immediate release as `v135`.

Closes GUS-W-11349438