### PR TITLE
Convert heroku/heroku-buildpack-jvm-common to GitHub Actions

### DIFF
--- a/.github/workflows/default-ci-workflow.yml
+++ b/.github/workflows/default-ci-workflow.yml
@@ -1,0 +1,109 @@
+name: heroku/heroku-buildpack-jvm-common/default-ci-workflow
+on:
+  workflow_dispatch:
+    inputs:
+      enable-hatchet-with-staging-bucket:
+        required: true
+env:
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+jobs:
+  shfmt:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: mvdan/shfmt:v3.1.2-alpine
+    steps:
+    - name: Install git
+      run: apk add git
+    - uses: actions/checkout@v2
+    - name: Run shfmt (excluding vendor directory)
+      run: shfmt -f . | grep -v "/vendor/" | xargs shfmt -i 2 -d
+  shellcheck:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: koalaman/shellcheck-alpine:v0.7.1
+    steps:
+    - name: Install git
+      run: apk add git
+    - uses: actions/checkout@v2
+    - name: Run shellcheck with fixed set of directories
+      run: shellcheck bin/* lib/jvm.sh etc/* opt/* test/*.sh
+  unit-tests-heroku-buildpack:
+    runs-on: sfdc-hk-ubuntu-latest
+    needs:
+    - shfmt
+    - shellcheck
+    env:
+      STACK: xxxxxxx
+    strategy:
+      matrix:
+        heroku-stack:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+    steps:
+    - uses: actions/checkout@v2
+    - run: test/v2
+    - run: test/jdbc.sh
+  buildpack-testrunner:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: openjdk:8.0
+    needs:
+    - shfmt
+    - shellcheck
+    env:
+      SHUNIT_HOME: xxxxxxx
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install required apt packages
+      run: |-
+        sudo apt-get update
+        sudo apt-get install file
+    - name: Download and unpack shunit 2.1.6
+      run: curl -sSf --retry 3 --retry-connrefused --connect-timeout 5 https://storage.googleapis.com/google-code-archive-downloads/v2/code.google.com/shunit2/shunit2-2.1.6.tgz | tar xz -C /tmp/
+    - name: Clone heroku-buildpack-testrunner
+      run: git clone https://github.com/heroku/heroku-buildpack-testrunner.git /tmp/testrunner
+    - name: Apply heroku-buildpack-testrunner patches to enforce bash shell
+      run: "cd /tmp/testrunner\ngit apply \\<<'EOF'\ndiff --git a/bin/run b/bin/run\nindex 0d5b790..a0ff25c 100755\n--- a/bin/run\n+++ b/bin/run\n@@ -101,7 +101,7 @@ for bp in ${@}; do\n     suite_start_time=\"$(date +%s)\"\n \n     echo \"  TEST SUITE: $(basename ${f})\"\n-    ${SHUNIT_HOME?\"'SHUNIT_HOME' environment variable must be set\"}/src/shunit2 ${f} | indent\n+    /bin/bash ${SHUNIT_HOME?\"'SHUNIT_HOME' environment variable must be set\"}/src/shunit2 ${f} | indent\n     exit_code=$(max ${exit_code} ${PIPESTATUS[0]})\n \n     suite_end_time=\"$(date +%s)\"\n\nEOF"
+    - name: Execute buildpack-testrunner
+      run: "/tmp/testrunner/bin/run ."
+  hatchet:
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    needs:
+    - shfmt
+    - shellcheck
+    env:
+      HATCHET_APP_LIMIT: xxxxxxx
+      PARALLEL_SPLIT_TEST_PROCESSES: xxxxxxx
+      HATCHET_BUILDPACK_BASE: xxxxxxx
+      HATCHET_BUILDPACK_BRANCH: xxxxxxx
+      DEFAULT_APP_STACK: xxxxxxx
+      DEFAULT_APP_CONFIG_JVM_COMMON_BUILDPACK: xxxxxxx
+      DEFAULT_APP_CONFIG_JVM_BUILDPACK_ASSETS_BASE_URL: xxxxxxx
+    strategy:
+      matrix:
+        heroku-stack:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+        use-staging-bucket: false
+    steps:
+    - uses: actions/checkout@v2
+    - shell: bash
+      run: |-
+        if [[ $(command -v heroku) == "" ]]; then
+          curl https://cli-assets.heroku.com/install.sh | sh
+        else
+          echo "Heroku is already installed. No operation was performed."
+        fi
+    - name: Install Ruby dependencies
+      run: |-
+        gem install bundler
+        bundle install
+    - name: Hatchet CI setup
+      run: bundle exec hatchet ci:setup
+    - name: Execute rspec w/ parallel_split_test
+      run: bundle exec parallel_split_test test/spec/

--- a/.github/workflows/hatchet-with-staging-bucket.yml
+++ b/.github/workflows/hatchet-with-staging-bucket.yml
@@ -1,0 +1,48 @@
+name: heroku/heroku-buildpack-jvm-common/hatchet-with-staging-bucket
+on:
+  workflow_dispatch:
+    inputs:
+      enable-hatchet-with-staging-bucket:
+        required: true
+env:
+  HEROKU_API_KEY: xxxxxxx
+  HEROKU_API_USER: xxxxxxx
+jobs:
+  hatchet:
+    if: << pipeline.parameters.enable-hatchet-with-staging-bucket >>
+    runs-on: sfdc-hk-ubuntu-latest
+    container:
+      image: ruby:2.7
+    env:
+      HATCHET_APP_LIMIT: xxxxxxx
+      PARALLEL_SPLIT_TEST_PROCESSES: xxxxxxx
+      HATCHET_BUILDPACK_BASE: xxxxxxx
+      HATCHET_BUILDPACK_BRANCH: xxxxxxx
+      DEFAULT_APP_STACK: xxxxxxx
+      DEFAULT_APP_CONFIG_JVM_COMMON_BUILDPACK: xxxxxxx
+      DEFAULT_APP_CONFIG_JVM_BUILDPACK_ASSETS_BASE_URL: xxxxxxx
+    strategy:
+      matrix:
+        heroku-stack:
+        - heroku-18
+        - heroku-20
+        - heroku-22
+        use-staging-bucket:
+        - true
+    steps:
+    - uses: actions/checkout@v2
+    - shell: bash
+      run: |-
+        if [[ $(command -v heroku) == "" ]]; then
+          curl https://cli-assets.heroku.com/install.sh | sh
+        else
+          echo "Heroku is already installed. No operation was performed."
+        fi
+    - name: Install Ruby dependencies
+      run: |-
+        gem install bundler
+        bundle install
+    - name: Hatchet CI setup
+      run: bundle exec hatchet ci:setup
+    - name: Execute rspec w/ parallel_split_test
+      run: bundle exec parallel_split_test test/spec/


### PR DESCRIPTION
Pipeline migrated from [Circle CI](https://app.circleci.com/pipelines/github/heroku/heroku-buildpack-jvm-common) :tada:

## Manual steps

Perform the follow steps to complete the migration:

### heroku/heroku-buildpack-jvm-common/default-ci-workflow
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest

### heroku/heroku-buildpack-jvm-common/hatchet-with-staging-bucket
- [ ] Ensure a runner with the following labels exists: sfdc-hk-ubuntu-latest