### PR TITLE
fix: ability to disable download of metrics agent

### DIFF
--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -161,6 +161,9 @@ install_jdk_overlay() {
 }
 
 install_metrics_agent() {
+  if [ -n "${DISABLE_HEROKU_METRICS_AGENT}" ]; then
+    return 0
+  fi
   local bpDir=${1:?}
   local installDir="${2:?}"
   local profileDir="${3:?}"


### PR DESCRIPTION
Currently one can't skip the download of the metrics agent.