### PR TITLE
Remove heroku-18 stack support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-18", "heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22"]
         assets-base-url: ["", "https://lang-jvm-staging2.s3.us-east-1.amazonaws.com/"]
     env:
       HATCHET_APP_LIMIT: 100
@@ -103,12 +103,12 @@ jobs:
     runs-on: ubuntu-22.04
     needs: lint
     container:
-      image: "${{ fromJson('{ \"heroku-18\": \"heroku/heroku:18\", \"heroku-20\": \"heroku/heroku:20\", \"heroku-22\": \"heroku/heroku:22\" }')[matrix.stack] }}"
+      image: "${{ fromJson('{ \"heroku-20\": \"heroku/heroku:20\", \"heroku-22\": \"heroku/heroku:22\" }')[matrix.stack] }}"
       env:
         STACK: ${{ matrix.stack }}
     strategy:
       matrix:
-        stack: ["heroku-18", "heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22"]
     steps:
       - uses: actions/checkout@v3
       - run: test/v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* Remove heroku-18 support ([#267](https://github.com/heroku/heroku-buildpack-jvm-common/pull/267))
+
 ## v144
 
 * Upgrade default JDKs to 20.0.1, 17.0.7, 11.0.19 and 8u372. ([#265](https://github.com/heroku/heroku-buildpack-jvm-common/pull/265))

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -24,7 +24,7 @@ if [[ -n "${JDK_BASE_URL}" ]]; then
   warning_inline "Support for the JDK_BASE_URL environment variable is deprecated and will be removed October 2021!"
 else
   JVM_BUILDPACK_ASSETS_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL:-"https://lang-jvm.s3.us-east-1.amazonaws.com"}"
-  JDK_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL%/}/jdk/${STACK:-"heroku-18"}"
+  JDK_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL%/}/jdk/${STACK:-"heroku-22"}"
 fi
 
 get_jdk_version() {
@@ -83,7 +83,7 @@ get_jdk_url() {
   openjdk-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion//openjdk-/openjdk}.tar.gz" ;;
   zulu-*) jdkUrl="${JDK_BASE_URL}/${jdkVersion}.tar.gz" ;;
   *)
-    if [ "${STACK}" == "heroku-18" ] || [ "${STACK}" == "heroku-20" ]; then
+    if [ "${STACK}" == "heroku-20" ]; then
       jdkUrl="${JDK_BASE_URL}/openjdk${jdkVersion}.tar.gz"
     else
       jdkUrl="${JDK_BASE_URL}/zulu-${jdkVersion}.tar.gz"

--- a/test/v2
+++ b/test/v2
@@ -237,7 +237,7 @@ test_install_jdk_invalid() {
 }
 
 test_get_jdk_url_with_default() {
-  if [ "${STACK}" == "heroku-18" ] || [ "${STACK}" == "heroku-20" ]; then
+  if [ "${STACK}" == "heroku-20" ]; then
     assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
 
     export JDK_URL_1_8="https://example.com/java8"


### PR DESCRIPTION
Since the Heroku-18 stack has reached end-of-life, and as such builds using it are no longer supported by the Heroku build system:
https://devcenter.heroku.com/changelog-items/2583

This fixes the integration tests failing in CI for the Heroku-18 stack, due to the build system now (as expected) rejecting the jobs.

Any non-Heroku consumers of this buildpack that wish to continue using the Heroku-18 stack should pin to the previous version of this buildpack.

Ref: GUS-W-10446298