### PR TITLE
Group minor/patch version Ruby Dependabot updates into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,18 @@ updates:
       interval: "monthly"
     labels:
       - "dependencies"
+      - "ruby"
+      - "skip changelog"
+    groups:
+      ruby-dependencies:
+        update-types:
+          - "minor"
+          - "patch"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "dependencies"
+      - "github actions"
       - "skip changelog"

--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -9,13 +9,11 @@ permissions:
 
 jobs:
   check-changelog:
-    runs-on: ubuntu-22.04
-    if: |
-      !contains(github.event.pull_request.labels.*.name, 'skip changelog') &&
-      !contains(github.event.pull_request.labels.*.name, 'dependencies')
+    runs-on: ubuntu-latest
+    if: (!contains(github.event.pull_request.labels.*.name, 'skip changelog'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Check that CHANGELOG is touched
         run: |
           git fetch origin ${{ github.base_ref }} --depth 1 && \


### PR DESCRIPTION
Ruby minor/patch dependencies will now be grouped, using the new Dependabot grouping feature:
https://github.blog/changelog/2023-08-17-grouped-version-updates-by-semantic-version-level-for-dependabot/

A GitHub Actions config has also been added, since one was missing.

In addition, the check changelog skipping strategy has been updated to use the `skip changelog` label for (a) explicitness, (b) to allow removing the label in situations where we realise a changelog entry is required, (c) for consistency with other repos.

GUS-W-14303554.