### PR TITLE
Don't default to Eco JVM settings for unknown dynos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Main
 
+* JVM runtime options for Dynos that are **not** `Eco`, `Basic`, `Standard-1X`, `Standard-2X`, `Performance-M` or `Performance-L` (or their Private Spaces equivalents) will no longer default to the options for `Eco` Dynos. Instead, JVM ergonomics will be used in conjunction with `-XX:MaxRAMPercentage=80.0` to ensure sensible defaults for such Dynos. ([#282](https://github.com/heroku/heroku-buildpack-jvm-common/pull/282))
+
 ## v148
 
 * Upgrade default JDKs to 21.0.1, 17.0.9, 11.0.21 and 8u392. ([#280](https://github.com/heroku/heroku-buildpack-jvm-common/pull/280))

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -5,6 +5,9 @@ calculate_java_memory_opts() {
 
   limit=$(ulimit -u)
   case $limit in
+  256) # Eco, Basic, 1X: memory.limit_in_bytes=536870912
+    echo "$opts -Xmx300m -Xss512k -XX:CICompilerCount=2"
+    ;;
   512) # 2X, private-s: memory.limit_in_bytes=1073741824
     echo "$opts -Xmx671m -XX:CICompilerCount=2"
     ;;
@@ -14,8 +17,12 @@ calculate_java_memory_opts() {
   32768) # perf-l, private-l: memory.limit_in_bytes=15032385536
     echo "$opts -Xmx12g"
     ;;
-  *) # Free, Hobby, 1X: memory.limit_in_bytes=536870912
-    echo "$opts -Xmx300m -Xss512k -XX:CICompilerCount=2"
+  *)
+    # Rely on JVM ergonomics for other dyno types, but increase the maximum RAM percentage from 25% to 80%.
+    # This is more consistent with the Heroku defaults for other dyno types. For example, a 32GB dyno would only use
+    # 8GB of heap with the 25% default, but performance-l with 14GB of memory would get 12GB max heap size as
+    # explicitly configured.
+    echo "$opts -XX:MaxRAMPercentage=80.0"
     ;;
   esac
 }


### PR DESCRIPTION
Currently, if a Dyno type cannot be determined via `ulimit -u` output matching the JVM options for `Eco` dynos will be used. These are the most aggressively and specifically tuned options for a low-memory environment. This PR changes this behaviour to explicitly match for `Eco`, `Basic` and `Standard-1X` dynos and default to using JVM ergonomics with a heap maximum of 80% of system memory.

JVM ergonomics work well enough as a default for environment that are not memory constrained. In addition, JVM ergonomics are not Heroku specific and should be less surprising for customers. 

We could potentially default `Performance-M` and `Performance-L` Dynos to JVM ergonomics as well, but I decided to keep the already established defaults to avoid surprising behaviour for existing customers. The only benefit for us would be the removal of two trivial lines of code. That said, it might be worth making this change for the CNB future.

I manually verified that the JVM settings on each existing Dyno type do not change between [main](https://github.com/heroku/heroku-buildpack-jvm-common/tree/main) and this PR.

Ref: GUS-W-4634736