### PR TITLE
Use cgroup memory limit for dyno type detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased]
 
 * Add support for Java 22. ([#292](https://github.com/heroku/heroku-buildpack-jvm-common/pull/292))
+* Use `/sys/fs/cgroup/memory/memory.limit_in_bytes` instead of `ulimit -u` for dyno type detection. ([#294](https://github.com/heroku/heroku-buildpack-jvm-common/pull/294))
 
 ## [v150] - 2024-01-17
 


### PR DESCRIPTION
Because `ulimit -u` can be ambiguous and we actually care about the available memory. I tested against all common runtime dyno sizes to ensure the correct JVM flags are used.