### PR TITLE
Add support for heroku-24 stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22", "heroku-24"]
         assets-base-url: ["", "https://lang-jvm-staging2.s3.us-east-1.amazonaws.com/"]
     env:
       HATCHET_APP_LIMIT: 100
@@ -103,12 +103,12 @@ jobs:
     runs-on: ubuntu-22.04
     needs: lint
     container:
-      image: "${{ fromJson('{ \"heroku-20\": \"heroku/heroku:20\", \"heroku-22\": \"heroku/heroku:22\" }')[matrix.stack] }}"
+      image: "${{ fromJson('{ \"heroku-20\": \"heroku/heroku:20\", \"heroku-22\": \"heroku/heroku:22\", \"heroku-24\": \"heroku/heroku:24\" }')[matrix.stack] }}"
       env:
         STACK: ${{ matrix.stack }}
     strategy:
       matrix:
-        stack: ["heroku-20", "heroku-22"]
+        stack: ["heroku-20", "heroku-22", "heroku-24"]
     steps:
       - uses: actions/checkout@v4
       - run: test/v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
     needs: lint
     container:
       image: "${{ fromJson('{ \"heroku-20\": \"heroku/heroku:20\", \"heroku-22\": \"heroku/heroku:22\", \"heroku-24\": \"heroku/heroku:24\" }')[matrix.stack] }}"
+      options: --user root
       env:
         STACK: ${{ matrix.stack }}
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Add support for `heroku-24` stack. ([#298](https://github.com/heroku/heroku-buildpack-jvm-common/pull/298))
 
 ## [v152] - 2024-05-01
 

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -2,7 +2,7 @@ require_relative 'spec_helper'
 
 describe "Java" do
 
-  ["1.8", "8", "11", "17", "22", "11.0.15", "openjdk-11.0.15", "zulu-11.0.15", "heroku-17", "zulu-17", "heroku-21", "zulu-21"].each do |jdk_version|
+  ["1.8", "8", "11", "17", "22", "11.0.23", "openjdk-11.0.23", "zulu-11.0.23", "heroku-17", "zulu-17", "heroku-21", "zulu-21"].each do |jdk_version|
     context "a simple java app on jdk-#{jdk_version}" do
       it "should deploy" do
         new_default_hatchet_runner("java-servlets-sample").tap do |app|

--- a/test/v2
+++ b/test/v2
@@ -130,41 +130,15 @@ test_installJavaCI() {
 
 test_installJavaWithVersion() {
   unset JAVA_HOME # unsets environment -- shunit doesn't clean environment before each test
-  capture install_java "${BUILD_DIR}" "1.8.0_332"
+  capture install_java "${BUILD_DIR}" "1.8.0_412"
   assertTrue "A .jdk directory should be created when installing java." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "The java runtime should be present." "[ -f ${BUILD_DIR}/.jdk/bin/java ]"
   assertEquals "${BUILD_DIR}/.jdk" "${JAVA_HOME}"
   assertContains "${PATH}" "${BUILD_DIR}/.jdk/bin"
   assertTrue "A version file should have been created." "[ -f ${BUILD_DIR}/.jdk/version ]"
-  assertEquals "$(cat "${BUILD_DIR}/.jdk/version")" "1.8.0_332"
+  assertEquals "$(cat "${BUILD_DIR}/.jdk/version")" "1.8.0_412"
   assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
   assertTrue "A profile.d file should have been created." "[ -f ${BUILD_DIR}/.profile.d/jvmcommon.sh ]"
-}
-
-test_upgradeFrom1_7To1_8() {
-  unset JAVA_HOME # unsets environment -- shunit doesn't clean environment before each test
-  capture install_java "${BUILD_DIR}" "1.7"
-  assertCapturedSuccess
-  assertTrue "Precondition: JDK 7 should have been installed." "[ $(cat "${BUILD_DIR}/.jdk/version") = '1.7' ]"
-  assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
-
-  capture install_java "${BUILD_DIR}" "1.8"
-  assertCapturedSuccess
-  assertEquals "$(cat "${BUILD_DIR}/.jdk/version")" "1.8"
-  assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
-}
-
-test_upgradeFrom1_8To1_7() {
-  unset JAVA_HOME # unsets environment -- shunit doesn't clean environment before each test
-  capture install_java "${BUILD_DIR}" "1.8"
-  assertCapturedSuccess
-  assertTrue "Precondition: JDK 8 should have been installed." "[ $(cat "${BUILD_DIR}/.jdk/version") = '1.8' ]"
-  assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
-
-  capture install_java "${BUILD_DIR}" "1.7"
-  assertCapturedSuccess
-  assertEquals "$(cat "${BUILD_DIR}/.jdk/version")" "1.7"
-  assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
 }
 
 test_install_tools() {
@@ -194,17 +168,17 @@ test_invalidJdkURL() {
 }
 
 test_customJdk() {
-  capture install_java "${BUILD_DIR}" "1.8.0_332"
+  capture install_java "${BUILD_DIR}" "1.8.0_412"
   assertCapturedSuccess
 }
 
 test_zuluJdk() {
-  capture install_java "${BUILD_DIR}" "zulu-1.8.0_332"
+  capture install_java "${BUILD_DIR}" "zulu-1.8.0_412"
   assertCapturedSuccess
 }
 
 test_openJdk() {
-  capture install_java "${BUILD_DIR}" "openjdk-1.8.0_332"
+  capture install_java "${BUILD_DIR}" "openjdk-1.8.0_412"
   assertCapturedSuccess
 }
 
@@ -231,49 +205,38 @@ test_install_jdk_invalid() {
 
   curl -sf --retry 3 --retry-connrefused --connect-timeout 5 -o "${key}" -L "https://www.php.net/distributions/php-keyring.gpg"
   export HEROKU_GPG_VALIDATION=1
-  capture install_jdk "${JDK_BASE_URL}/openjdk11.0.8.tar.gz" "$(mktemp -d)" "${BUILDPACK_HOME}" "${key}"
+  capture install_jdk "${JDK_BASE_URL}/openjdk11.0.23.tar.gz" "$(mktemp -d)" "${BUILDPACK_HOME}" "${key}"
   assertCapturedError " !     ERROR: Invalid GPG signature!"
   unset HEROKU_GPG_VALIDATION
 }
 
 test_get_jdk_url_with_default() {
   if [ "${STACK}" == "heroku-20" ]; then
-    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_412.tar.gz" "$(_get_jdk_url_with_default "1.8.0_412")"
 
     export JDK_URL_1_8="https://example.com/java8"
-    assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_332")"
-    assertEquals "${JDK_BASE_URL:?}/openjdk1.7.0_272.tar.gz" "$(_get_jdk_url_with_default "1.7.0_272")"
-    assertEquals "${JDK_BASE_URL:?}/openjdk11.0.8.tar.gz" "$(_get_jdk_url_with_default "11.0.8")"
-    assertEquals "${JDK_BASE_URL:?}/zulu-11.0.8.tar.gz" "$(_get_jdk_url_with_default "zulu-11.0.8")"
+    assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_412")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk11.0.23.tar.gz" "$(_get_jdk_url_with_default "11.0.23")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-11.0.23.tar.gz" "$(_get_jdk_url_with_default "zulu-11.0.23")"
     unset JDK_URL_1_8
 
-    export JDK_URL_1_7="https://example.com/java7"
-    assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_272")"
-    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
-    unset JDK_URL_1_7
-
     export JDK_URL_11="https://example.com/java11"
-    assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.8")"
-    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.23")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk1.8.0_412.tar.gz" "$(_get_jdk_url_with_default "1.8.0_412")"
     unset JDK_URL_11
   else
-    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_412.tar.gz" "$(_get_jdk_url_with_default "1.8.0_412")"
 
     export JDK_URL_1_8="https://example.com/java8"
-    assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_URL_1_8}" "$(_get_jdk_url_with_default "1.8.0_412")"
     assertEquals "${JDK_BASE_URL:?}/zulu-1.7.0_272.tar.gz" "$(_get_jdk_url_with_default "1.7.0_272")"
-    assertEquals "${JDK_BASE_URL:?}/zulu-11.0.8.tar.gz" "$(_get_jdk_url_with_default "11.0.8")"
-    assertEquals "${JDK_BASE_URL:?}/openjdk11.0.8.tar.gz" "$(_get_jdk_url_with_default "openjdk-11.0.8")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-11.0.23.tar.gz" "$(_get_jdk_url_with_default "11.0.23")"
+    assertEquals "${JDK_BASE_URL:?}/openjdk11.0.23.tar.gz" "$(_get_jdk_url_with_default "openjdk-11.0.23")"
     unset JDK_URL_1_8
 
-    export JDK_URL_1_7="https://example.com/java7"
-    assertEquals "${JDK_URL_1_7}" "$(_get_jdk_url_with_default "1.7.0_272")"
-    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
-    unset JDK_URL_1_7
-
     export JDK_URL_11="https://example.com/java11"
-    assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.8")"
-    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_332.tar.gz" "$(_get_jdk_url_with_default "1.8.0_332")"
+    assertEquals "${JDK_URL_11}" "$(_get_jdk_url_with_default "11.0.23")"
+    assertEquals "${JDK_BASE_URL:?}/zulu-1.8.0_412.tar.gz" "$(_get_jdk_url_with_default "1.8.0_412")"
     unset JDK_URL_11
   fi
 }


### PR DESCRIPTION
Add support for `heroku-24` stack. Test related to Java 7 have been removed since this EOL version is longer part of `heroku-24`. Bumped tested explicit versions as well since older releases are not available on heroku-24 either.

GUS-W-14666742