### PR TITLE
Use latest OpenJDK LTS as default on heroku-24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Default version for the `heroku-24` stack is now always the latest long-term support version, currently `21`. ([#300](https://github.com/heroku/heroku-buildpack-jvm-common/pull/300))
 
 ## [v153] - 2024-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-* Default version for the `heroku-24` stack is now always the latest long-term support version, currently `21`. ([#300](https://github.com/heroku/heroku-buildpack-jvm-common/pull/300))
+* Default JDK version for the `heroku-24` stack is now always the latest long-term support version, currently `21`. ([#300](https://github.com/heroku/heroku-buildpack-jvm-common/pull/300))
 
 ## [v153] - 2024-05-21
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-DEFAULT_JDK_VERSION="1.8"
+STACK="${STACK:-"heroku-24"}"
+
+if [ "${STACK}" == "heroku-24" ]; then
+  # This should always be the latest OpenJDK LTS major version
+  # Next LTS will be OpenJDK 25 with a planned release date of 2025-09-16
+  DEFAULT_JDK_VERSION="21"
+else
+  DEFAULT_JDK_VERSION="1.8"
+fi
 
 DEFAULT_JDK_1_8_VERSION="1.8.0_412"
 DEFAULT_JDK_11_VERSION="11.0.23"
@@ -26,7 +34,7 @@ if [[ -n "${JDK_BASE_URL:-}" ]]; then
   warning_inline "Support for the JDK_BASE_URL environment variable is deprecated and will be removed October 2021!"
 else
   JVM_BUILDPACK_ASSETS_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL:-"https://lang-jvm.s3.us-east-1.amazonaws.com"}"
-  JDK_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL%/}/jdk/${STACK:-"heroku-22"}"
+  JDK_BASE_URL="${JVM_BUILDPACK_ASSETS_BASE_URL%/}/jdk/${STACK}"
 fi
 
 get_jdk_version() {
@@ -87,7 +95,7 @@ get_jdk_url() {
   openjdk-*) jdkUrl="${JDK_BASE_URL:-}/${jdkVersion//openjdk-/openjdk}.tar.gz" ;;
   zulu-*) jdkUrl="${JDK_BASE_URL:-}/${jdkVersion}.tar.gz" ;;
   *)
-    if [ "${STACK:-}" == "heroku-20" ]; then
+    if [ "${STACK}" == "heroku-20" ]; then
       jdkUrl="${JDK_BASE_URL:-}/openjdk${jdkVersion}.tar.gz"
     else
       jdkUrl="${JDK_BASE_URL:-}/zulu-${jdkVersion}.tar.gz"

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -12,55 +12,55 @@ testCompileWithoutSystemProperties() {
 
   assertCapturedSuccess
 
-  assertCaptured "Installing OpenJDK 1.8"
+  assertCaptured "Installing OpenJDK 21"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
 
-testCompileWith_1_8_0_372() {
-  echo "java.runtime.version=1.8.0_372" >"${BUILD_DIR}/system.properties"
+testCompileWith_1_8_0_412() {
+  echo "java.runtime.version=1.8.0_412" >"${BUILD_DIR}/system.properties"
 
   compile
 
   assertCapturedSuccess
 
-  assertCaptured "Installing OpenJDK 1.8.0_372"
+  assertCaptured "Installing OpenJDK 1.8.0_412"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
 
-testCompileWith_zulu_1_8_0_372() {
-  echo "java.runtime.version=zulu-1.8.0_372" >"${BUILD_DIR}/system.properties"
+testCompileWith_zulu_1_8_0_412() {
+  echo "java.runtime.version=zulu-1.8.0_412" >"${BUILD_DIR}/system.properties"
 
   compile
 
   assertCapturedSuccess
 
-  assertCaptured "Installing Azul Zulu OpenJDK 1.8.0_372"
+  assertCaptured "Installing Azul Zulu OpenJDK 1.8.0_412"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
 
-testCompileWith_openjdk_1_8_0_372() {
-  echo "java.runtime.version=openjdk-1.8.0_372" >"${BUILD_DIR}/system.properties"
+testCompileWith_openjdk_1_8_0_412() {
+  echo "java.runtime.version=openjdk-1.8.0_412" >"${BUILD_DIR}/system.properties"
 
   compile
 
   assertCapturedSuccess
 
-  assertCaptured "Installing Heroku OpenJDK 1.8.0_372"
+  assertCaptured "Installing Heroku OpenJDK 1.8.0_412"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }
 
 testCompileWith_zulu_11_0_15() {
-  echo "java.runtime.version=zulu-11.0.15" >"${BUILD_DIR}/system.properties"
+  echo "java.runtime.version=zulu-11.0.23" >"${BUILD_DIR}/system.properties"
 
   compile
 
   assertCapturedSuccess
 
-  assertCaptured "Installing Azul Zulu OpenJDK 11.0.15"
+  assertCaptured "Installing Azul Zulu OpenJDK 11.0.23"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"
 }

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -29,13 +29,17 @@ describe "Java" do
 
   context "a system.properties file with no java.runtime.version" do
     it "should deploy" do
-      expected_version = "1.8"
       new_default_hatchet_runner("java-servlets-sample").tap do |app|
         app.before_deploy do
           write_sys_props(Dir.pwd, "maven.version=3.3.9")
         end
         app.deploy do
-          expect(app.output).to include("Installing OpenJDK #{expected_version}")
+          if app.stack == "heroku-24" then
+            expect(app.output).to include("Installing OpenJDK 21")
+          else
+            expect(app.output).to include("Installing OpenJDK 1.8")
+          end
+
           expect(app.output).to include("BUILD SUCCESS")
           expect(successful_body(app)).to eq("Hello from Java!")
         end

--- a/test/v2
+++ b/test/v2
@@ -116,7 +116,6 @@ test_installDefaultJava() {
 
   assertEquals "${BUILD_DIR}/.jdk/bin/java" "$(command -v java)"
   assertTrue "A profile.d file should have been created." "[ -f ${BUILD_DIR}/.profile.d/jvmcommon.sh ]"
-  assertTrue "A pgconfig.jar should exist in the JDK" "[ -f ${BUILD_DIR}/.jdk/jre/lib/ext/pgconfig.jar ]"
 }
 
 test_installJavaCI() {


### PR DESCRIPTION
 Default version for the `heroku-24` stack is now always the latest long-term support version, currently `21`. Other stacks continue to use the current default of `8` for now and will change at a later date.

A separate PR will follow that logs a warning message when the default version is being used.

GUS-W-15880423