### PR TITLE
Warn when default OpenJDK version is being used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+* The buildpack now warns when no OpenJDK version is explicitly specified. Users are encouraged to specify a version to ensure future builds use the same OpenJDK version. ([#301](https://github.com/heroku/heroku-buildpack-jvm-common/pull/301))
+
 ### Changed
 
 * Default JDK version for the `heroku-24` stack is now always the latest long-term support version, currently `21`. ([#300](https://github.com/heroku/heroku-buildpack-jvm-common/pull/300))

--- a/bin/java
+++ b/bin/java
@@ -17,29 +17,32 @@ install_java_with_overlay() {
     if [ -z "$(_get_system_property "${buildDir}/system.properties" "java.runtime.version")" ]; then
       if [ "${STACK}" == "heroku-24" ]; then
         warning "No OpenJDK version specified
-Your application does not explicitly specify an OpenJDK version. The latest
-long-term support (LTS) version will be installed. This currently is OpenJDK ${DEFAULT_JDK_VERSION}.
+Your application does not explicitly specify an OpenJDK
+version. The latest long-term support (LTS) version will be
+installed. This currently is OpenJDK ${DEFAULT_JDK_VERSION}.
 
-This default version will change when a new LTS version is released. Your
-application might fail to build with the new version. We recommend explicitly
-setting the required OpenJDK version for your application.
+This default version will change when a new LTS version is
+released. Your application might fail to build with the new
+version. We recommend explicitly setting the required OpenJDK
+version for your application.
 
-To set the OpenJDK version, add or edit the system.properties file in the root
-directory of your application to contain:
+To set the OpenJDK version, add or edit the system.properties
+file in the root directory of your application to contain:
 
 java.runtime.version = ${DEFAULT_JDK_VERSION}
 "
       else
         warning "No OpenJDK version specified
-Your application does not explicitly specify an OpenJDK version.
-OpenJDK ${DEFAULT_JDK_VERSION} will be installed.
+Your application does not explicitly specify an OpenJDK
+version. OpenJDK ${DEFAULT_JDK_VERSION} will be installed.
 
 This default version will change at some point. Your
-application might fail to build with the new version. We recommend explicitly
-setting the required OpenJDK version for your application.
+application might fail to build with the new version. We
+recommend explicitly setting the required OpenJDK version for
+your application.
 
-To set the OpenJDK version, add or edit the system.properties file in the root
-directory of your application to contain:
+To set the OpenJDK version, add or edit the system.properties
+file in the root directory of your application to contain:
 
 java.runtime.version = ${DEFAULT_JDK_VERSION}
 "

--- a/bin/java
+++ b/bin/java
@@ -14,6 +14,38 @@ install_java_with_overlay() {
   local buildDir="${1}"
   local cacheDir="${2:-$(mktemp -d)}"
   if [ ! -f "${buildDir}/.jdk/bin/java" ]; then
+    if [ -z "$(_get_system_property "${buildDir}/system.properties" "java.runtime.version")" ]; then
+      if [ "${STACK}" == "heroku-24" ]; then
+        warning "No OpenJDK version specified
+Your application does not explicitly specify an OpenJDK version. The latest
+long-term support (LTS) version will be installed. This currently is OpenJDK ${DEFAULT_JDK_VERSION}.
+
+This default version will change when a new LTS version is released. Your
+application might fail to build with the new version. We recommend explicitly
+setting the required OpenJDK version for your application.
+
+To set the OpenJDK version, add or edit the system.properties file in the root
+directory of your application to contain:
+
+java.runtime.version = ${DEFAULT_JDK_VERSION}
+"
+      else
+        warning "No OpenJDK version specified
+Your application does not explicitly specify an OpenJDK version.
+OpenJDK ${DEFAULT_JDK_VERSION} will be installed.
+
+This default version will change at some point. Your
+application might fail to build with the new version. We recommend explicitly
+setting the required OpenJDK version for your application.
+
+To set the OpenJDK version, add or edit the system.properties file in the root
+directory of your application to contain:
+
+java.runtime.version = ${DEFAULT_JDK_VERSION}
+"
+      fi
+    fi
+
     local jdkVersion
     jdkVersion=$(get_jdk_version "${buildDir}")
 

--- a/lib/jvm.sh
+++ b/lib/jvm.sh
@@ -39,15 +39,12 @@ fi
 
 get_jdk_version() {
   local appDir="${1:?}"
-  if [ -f "${appDir}/system.properties" ]; then
-    detectedVersion="$(_get_system_property "${appDir}/system.properties" "java.runtime.version")"
-    if [ -n "$detectedVersion" ]; then
-      echo "$detectedVersion"
-    else
-      echo "$DEFAULT_JDK_VERSION"
-    fi
+
+  configuredVersion="$(_get_system_property "${appDir}/system.properties" "java.runtime.version")"
+  if [ -n "${configuredVersion}" ]; then
+    echo "${configuredVersion}"
   else
-    echo "$DEFAULT_JDK_VERSION"
+    echo "${DEFAULT_JDK_VERSION}"
   fi
 }
 
@@ -208,7 +205,10 @@ _get_system_property() {
   local escaped_key
   escaped_key="${key//\./\\.}"
 
-  [ -f "$file" ] &&
-    grep -E "^${escaped_key}[[:space:]=]+" "$file" |
-    sed -E -e "s/$escaped_key([\ \t]*=[\ \t]*|[\ \t]+)([_A-Za-z0-9\.-]*).*/\2/g"
+  if [ -f "${file}" ]; then
+    grep -E "^${escaped_key}[[:space:]=]+" "${file}" |
+      sed -E -e "s/${escaped_key}([\ \t]*=[\ \t]*|[\ \t]+)([_A-Za-z0-9\.-]*).*/\2/g"
+  else
+    echo ""
+  fi
 }

--- a/test/compile_test.sh
+++ b/test/compile_test.sh
@@ -12,6 +12,7 @@ testCompileWithoutSystemProperties() {
 
   assertCapturedSuccess
 
+  assertCaptured "WARNING: No OpenJDK version specified"
   assertCaptured "Installing OpenJDK 21"
   assertTrue "Java should be present in runtime." "[ -d ${BUILD_DIR}/.jdk ]"
   assertTrue "Java version file should be present." "[ -f ${BUILD_DIR}/.jdk/version ]"

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -19,6 +19,8 @@ describe "Java" do
             else
               expect(app.output).to include("Installing OpenJDK #{jdk_version}")
             end
+
+            expect(app.output).not_to include("WARNING: No OpenJDK version specified")
             expect(app.output).to include("BUILD SUCCESS")
             expect(successful_body(app)).to eq("Hello from Java!")
           end
@@ -34,6 +36,8 @@ describe "Java" do
           write_sys_props(Dir.pwd, "maven.version=3.3.9")
         end
         app.deploy do
+          expect(app.output).to include("WARNING: No OpenJDK version specified")
+
           if app.stack == "heroku-24" then
             expect(app.output).to include("Installing OpenJDK 21")
           else
@@ -64,6 +68,8 @@ describe "Java" do
             else
               expect(app.output).to include("Installing OpenJDK #{jdk_version}")
             end
+
+            expect(app.output).not_to include("WARNING: No OpenJDK version specified")
             expect(app.output).to include("BUILD SUCCESS")
 
             # Workaround (August 2020):


### PR DESCRIPTION
This PR adds a warning message when the user does not specify an explicit OpenJDK version for their app. The warning includes instructions how to set the version as well.

We want to change the default version policy for OpenJDK at some point. This warning is a first step to get more users to specify a version and to inform them that this version might change in the future. The messages are slightly different between `heroku-24` and other stacks, as the default version policy is "latest LTS" for `heroku-24`, but not for other stacks. The message for non `heroku-24` stacks will change in the future, adding a link to a [Heroku Changelog](https://devcenter.heroku.com/changelog) entry announcing a policy change.

The same warning has been added to the Cloud Native Buildpack already in https://github.com/heroku/buildpacks-jvm/pull/681.

### Heroku-20 and Heroku-22

```
remote: -----> Building on the Heroku-22 stack
remote: -----> Using buildpack: heroku/java
remote: -----> Java app detected
remote:
remote:  !     WARNING: No OpenJDK version specified
remote:        Your application does not explicitly specify an OpenJDK
remote:        version. OpenJDK 1.8 will be installed.
remote:
remote:        This default version will change at some point. Your
remote:        application might fail to build with the new version. We
remote:        recommend explicitly setting the required OpenJDK version for
remote:        your application.
remote:
remote:        To set the OpenJDK version, add or edit the system.properties
remote:        file in the root directory of your application to contain:
remote:
remote:        java.runtime.version = 1.8
remote:
remote:
remote: -----> Installing OpenJDK 1.8... done
remote: -----> Installing Maven 3.9.4... done
remote: -----> Executing Maven
remote:        $ mvn -DskipTests clean dependency:list install
remote:        [INFO] Scanning for projects...
remote:        [INFO]
```

### Heroku-24

```
remote: -----> Building on the Heroku-24 stack
remote: -----> Using buildpack: heroku/java
remote: -----> Java app detected
remote:
remote:  !     WARNING: No OpenJDK version specified
remote:        Your application does not explicitly specify an OpenJDK
remote:        version. The latest long-term support (LTS) version will be
remote:        installed. This currently is OpenJDK 21.
remote:
remote:        This default version will change when a new LTS version is
remote:        released. Your application might fail to build with the new
remote:        version. We recommend explicitly setting the required OpenJDK
remote:        version for your application.
remote:
remote:        To set the OpenJDK version, add or edit the system.properties
remote:        file in the root directory of your application to contain:
remote:
remote:        java.runtime.version = 21
remote:
remote:
remote: -----> Installing OpenJDK 21... done
remote: -----> Installing Maven 3.9.4... done
remote: -----> Executing Maven
remote:        $ mvn -DskipTests clean dependency:list install
remote:        [INFO] Scanning for projects...
remote:        [INFO]
```

GUS-W-15880692