### PR TITLE
Port Python Buildpack Makefile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,15 @@ jobs:
       - uses: actions/checkout@v4
       - run: test/v2
       - run: test/jdbc.sh
+
+  container-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      # These test both the local development `make run` workflow and that `bin/report` completes successfully
+      # for both passing and failing builds (since `bin/report` can't easily be tested via Hatchet tests).
+      - name: Run buildpack using default app fixture
+        run: make run
+      #- name: Run buildpack using an app fixture that's expected to fail
+      #  run: make run FIXTURE=spec/fixtures/failing/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,15 +11,14 @@ permissions:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Install shfmt
         run: sudo apt-get install shfmt
-      - name: Run shfmt (excluding vendor code and fixtures)
-        run: shfmt -f . | grep -v "vendor/" | grep -v "test/spec/fixtures/" | xargs shfmt -i 2 -d
-      - name: Run ShellCheck
-        run: shellcheck bin/* lib/jvm.sh etc/* opt/* test/*.sh
+      - run: make lint-scripts
+      - run: make check-format
 
   hatchet:
     name: "Hatchet (${{ matrix.stack }}, ${{ matrix.assets-base-url == 0 && 'production bucket' || 'staging bucket' }})"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# These targets are not files
+.PHONY: lint lint-scripts check-format format run publish
+
+STACK ?= heroku-24
+FIXTURE ?= test/spec/fixtures/repos/java-overlay-test
+
+# Converts a stack name of `heroku-NN` to its build Docker image tag of `heroku/heroku:NN-build`.
+STACK_IMAGE_TAG := heroku/$(subst -,:,$(STACK))-build
+
+lint: lint-scripts check-format
+
+lint-scripts:
+	@git ls-files -z --cached --others --exclude-standard 'bin/*' 'etc/*' 'lib/*' 'opt/*' | xargs -0 shellcheck --check-sourced --color=always
+
+check-format:
+	@shfmt -f . | grep -v "vendor/" | grep -v "test/spec/fixtures/" | xargs shfmt -i 2 --diff
+
+format:
+	@shfmt -f . | grep -v "vendor/" | grep -v "test/spec/fixtures/" | xargs shfmt -i 2 --write --list
+
+run:
+	@echo "Running buildpack using: STACK=$(STACK) FIXTURE=$(FIXTURE)"
+	@docker run --rm -v $(PWD):/src:ro --tmpfs /app -e "HOME=/app" -e "STACK=$(STACK)" "$(STACK_IMAGE_TAG)" \
+		bash -euo pipefail -c '\
+			mkdir /tmp/buildpack /tmp/build /tmp/cache /tmp/env; \
+			cp -r /src/{bin,lib,opt} /tmp/buildpack; \
+			cp -rT /src/$(FIXTURE) /tmp/build; \
+			cd /tmp/buildpack; \
+			unset $$(printenv | cut -d '=' -f 1 | grep -vE "^(HOME|LANG|PATH|STACK)$$"); \
+			echo -e "\n~ Detect:" && ./bin/detect /tmp/build; \
+			echo -e "\n~ Compile:" && { ./bin/compile /tmp/build /tmp/cache /tmp/env || COMPILE_FAILED=1; }; \
+			echo -e "\n~ Report:" && ./bin/report /tmp/build /tmp/cache /tmp/env; \
+			[[ "$${COMPILE_FAILED:-}" == "1" ]] && exit 0; \
+			[[ -f /tmp/build/bin/compile ]] && { echo -e "\n~ Compile (Inline Buildpack):" && (source ./export && /tmp/build/bin/compile /tmp/build /tmp/cache /tmp/env); }; \
+			echo -e "\n~ Release:" && ./bin/release /tmp/build; \
+			echo -e "\nBuild successful!"; \
+		'
+	@echo
+
+publish:
+	@etc/publish.sh

--- a/bin/report
+++ b/bin/report
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Usage: bin/report <build-dir> <cache-dir> <env-dir>
+
+# Produces a build report containing metadata about the build, that's consumed by the build system.
+# This script is run for both successful and failing builds, so it should not assume the build ran
+# to completion (e.g. OpenJDK may not even have been installed).
+#
+# Metadata must be emitted to stdout as valid YAML key-value pairs. Any fields that should always
+# be typed as a string must be explicitly quoted.
+#
+# Example valid stdout:
+#   openjdk_version: 'X.Y.Z'
+#   openjdk_install_duration: 1.234
+#
+# Failures in this script don't cause the overall build to fail (and won't appear in user
+# facing build logs) to avoid breaking builds unnecessarily / causing confusion. To debug
+# issues check the internal build system logs for `buildpack.report.failed` events, or
+# when developing run `make compile` in this repo locally, which runs `bin/report` too.
+
+# There is no reporting at this point in time. It will be implemented later.

--- a/bin/report
+++ b/bin/report
@@ -15,6 +15,6 @@
 # Failures in this script don't cause the overall build to fail (and won't appear in user
 # facing build logs) to avoid breaking builds unnecessarily / causing confusion. To debug
 # issues check the internal build system logs for `buildpack.report.failed` events, or
-# when developing run `make compile` in this repo locally, which runs `bin/report` too.
+# when developing run `make run` in this repo locally, which runs `bin/report` too.
 
 # There is no reporting at this point in time. It will be implemented later.


### PR DESCRIPTION
Ports the `Makefile` from https://github.com/heroku/heroku-buildpack-python almost verbatim, changes CI to use the targets from the Makefile and adds a stub `bin/report` so that the Makefile doesn't need to be modified for a missing `bin/report` that will be added soon anyways.