### PR TITLE
Port Python buildpack output.sh

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -10,42 +10,49 @@ if [ -f "${JVM_COMMON_DIR}/lib/jvm.sh" ]; then
 	source "${JVM_COMMON_DIR}/lib/jvm.sh"
 fi
 
+# shellcheck source=lib/output.sh
+source "${JVM_COMMON_DIR}/lib/output.sh"
+
 install_java_with_overlay() {
 	local buildDir="${1}"
 	local cacheDir="${2:-$(mktemp -d)}"
 	if [ ! -f "${buildDir}/.jdk/bin/java" ]; then
 		if [ -z "$(_get_system_property "${buildDir}/system.properties" "java.runtime.version")" ]; then
 			if [ "${STACK}" == "heroku-24" ]; then
-				warning "No OpenJDK version specified
-Your application does not explicitly specify an OpenJDK
-version. The latest long-term support (LTS) version will be
-installed. This currently is OpenJDK ${DEFAULT_JDK_VERSION}.
+				output::warning <<-EOF
+					WARNING: No OpenJDK version specified
 
-This default version will change when a new LTS version is
-released. Your application might fail to build with the new
-version. We recommend explicitly setting the required OpenJDK
-version for your application.
+					Your application does not explicitly specify an OpenJDK
+					version. The latest long-term support (LTS) version will be
+					installed. This currently is OpenJDK ${DEFAULT_JDK_VERSION}.
 
-To set the OpenJDK version, add or edit the system.properties
-file in the root directory of your application to contain:
+					This default version will change when a new LTS version is
+					released. Your application might fail to build with the new
+					version. We recommend explicitly setting the required OpenJDK
+					version for your application.
 
-java.runtime.version = ${DEFAULT_JDK_VERSION}
-"
+					To set the OpenJDK version, add or edit the system.properties
+					file in the root directory of your application to contain:
+
+					java.runtime.version = ${DEFAULT_JDK_VERSION}
+				EOF
 			else
-				warning "No OpenJDK version specified
-Your application does not explicitly specify an OpenJDK
-version. OpenJDK ${DEFAULT_JDK_VERSION} will be installed.
+				output::warning <<-EOF
+					WARNING: No OpenJDK version specified
 
-This default version will change at some point. Your
-application might fail to build with the new version. We
-recommend explicitly setting the required OpenJDK version for
-your application.
+					Your application does not explicitly specify an OpenJDK
+					version. OpenJDK ${DEFAULT_JDK_VERSION} will be installed.
 
-To set the OpenJDK version, add or edit the system.properties
-file in the root directory of your application to contain:
+					This default version will change at some point. Your
+					application might fail to build with the new version. We
+					recommend explicitly setting the required OpenJDK version for
+					your application.
 
-java.runtime.version = ${DEFAULT_JDK_VERSION}
-"
+					To set the OpenJDK version, add or edit the system.properties
+					file in the root directory of your application to contain:
+
+					java.runtime.version = ${DEFAULT_JDK_VERSION}
+				EOF
 			fi
 		fi
 
@@ -57,24 +64,23 @@ java.runtime.version = ${DEFAULT_JDK_VERSION}
 
 		_jvm_mcount "version.${jdkVersion}"
 		if [[ "$jdkVersion" == *openjdk* ]]; then
-			status_pending "Installing Heroku OpenJDK $(_get_openjdk_version "${jdkVersion}")"
+			output::step "Installing Heroku OpenJDK $(_get_openjdk_version "${jdkVersion}")"
 			_jvm_mcount "vendor.openjdk"
 		elif [[ "$jdkVersion" == *heroku* ]]; then
-			status_pending "Installing Heroku OpenJDK $(_get_heroku_version "${jdkVersion}")"
+			output::step "Installing Heroku OpenJDK $(_get_heroku_version "${jdkVersion}")"
 			_jvm_mcount "vendor.openjdk"
 		elif [[ "$jdkVersion" == *zulu* ]]; then
-			status_pending "Installing Azul Zulu OpenJDK $(_get_zulu_version "${jdkVersion}")"
+			output::step "Installing Azul Zulu OpenJDK $(_get_zulu_version "${jdkVersion}")"
 			_jvm_mcount "vendor.zulu"
 		else
-			status_pending "Installing OpenJDK ${jdkVersion}"
+			output::step "Installing OpenJDK ${jdkVersion}"
 			_jvm_mcount "vendor.default"
 		fi
 		install_java "${buildDir}" "${jdkVersion}" "${jdkUrl}"
 		install_jdk_overlay "${buildDir}/.jdk" "${buildDir}"
 		_cache_version "${jdkVersion}" "${cacheDir}"
-		status_done
 	else
-		status "Using provided JDK"
+		output::step "Using provided JDK"
 		_jvm_mcount "vendor.provided"
 	fi
 }

--- a/bin/java
+++ b/bin/java
@@ -102,7 +102,10 @@ install_java() {
 		install_certs "${jdkDir}"
 		echo "${jdkVersion}" >"${jdkDir}/version"
 		if [ ! -f "${javaExe}" ]; then
-			error_return "Unable to retrieve the JDK."
+			output::error <<-EOF
+				Unable to retrieve the JDK.
+			EOF
+
 			return 1
 		fi
 	fi

--- a/bin/java
+++ b/bin/java
@@ -121,19 +121,21 @@ validate_jdk_url() {
 	local jdkUrl=${1}
 	local jdkVersion=${2}
 	if [ "$(_get_url_status "${jdkUrl}")" != "200" ]; then
-		echo ""
-		error_return "Unsupported Java version: $jdkVersion
+		output::error <<-EOF
+			ERROR: Unsupported Java version: ${jdkVersion}
 
-Please check your system.properties file to ensure the java.runtime.version
-is among the list of supported version on the Dev Center:
-https://devcenter.heroku.com/articles/java-support#supported-java-versions
-You can also remove the system.properties from your repo to install
-the default ${DEFAULT_JDK_VERSION} version.
-If you continue to have trouble, you can open a support ticket here:
-https://help.heroku.com
+			Please check your system.properties file to ensure the java.runtime.version
+			is among the list of supported version on the Dev Center:
+			https://devcenter.heroku.com/articles/java-support#supported-java-versions
+			You can also remove the system.properties from your repo to install
+			the default ${DEFAULT_JDK_VERSION} version.
+			If you continue to have trouble, you can open a support ticket here:
+			https://help.heroku.com
 
-Thanks,
-Heroku"
+			Thanks,
+			Heroku
+		EOF
+
 		return 1
 	fi
 }

--- a/bin/util
+++ b/bin/util
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# While these logging/output functions seem unused, they are used by downstream buildpacks that source this file.
+# Do not delete them before making sure that all known downstream buildpacks do not use these anymore.
+
 error() {
 	echo
 	echo " !     ERROR: $*" | indent no_first_line_indent

--- a/lib/output.sh
+++ b/lib/output.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+ANSI_BLUE='\033[1;34m'
+ANSI_RED='\033[1;31m'
+ANSI_YELLOW='\033[1;33m'
+ANSI_RESET='\033[0m'
+
+# Output a single line step message to stdout.
+#
+# Usage:
+# ```
+# output::step "Installing Python ..."
+# ```
+function output::step() {
+	echo "-----> ${1}"
+}
+
+# Indent passed stdout. Typically used to indent command output within a step.
+#
+# Usage:
+# ```
+# pip install ... | output::indent
+# ```
+function output::indent() {
+	sed --unbuffered "s/^/       /"
+}
+
+# Output a styled multi-line notice message to stderr.
+#
+# Usage:
+# ```
+# output::notice <<-EOF
+# 	Note: The note summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::notice() {
+	local line
+	echo >&2
+	while IFS= read -r line; do
+		echo -e "${ANSI_BLUE} !     ${line}${ANSI_RESET}" >&2
+	done
+	echo >&2
+}
+
+# Output a styled multi-line warning message to stderr.
+#
+# Usage:
+# ```
+# output::warning <<-EOF
+# 	Warning: The warning summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::warning() {
+	local line
+	echo >&2
+	while IFS= read -r line; do
+		echo -e "${ANSI_YELLOW} !     ${line}${ANSI_RESET}" >&2
+	done
+	echo >&2
+}
+
+# Output a styled multi-line error message to stderr.
+#
+# Usage:
+# ```
+# output::error <<-EOF
+# 	Error: The error summary.
+#
+# 	Detailed description.
+# EOF
+# ```
+function output::error() {
+	local line
+	echo >&2
+	while IFS= read -r line; do
+		echo -e "${ANSI_RED} !     ${line}${ANSI_RESET}" >&2
+	done
+	echo >&2
+}

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -162,19 +162,18 @@ RSpec.describe 'Java installation' do
           remote: -----> JVM Common app detected
           remote: -----> Installing OpenJDK .NET
           remote: 
-          remote: 
           remote:  !     ERROR: Unsupported Java version: .NET
-          remote:        
-          remote:        Please check your system.properties file to ensure the java.runtime.version
-          remote:        is among the list of supported version on the Dev Center:
-          remote:        https://devcenter.heroku.com/articles/java-support#supported-java-versions
-          remote:        You can also remove the system.properties from your repo to install
-          remote:        the default 21 version.
-          remote:        If you continue to have trouble, you can open a support ticket here:
-          remote:        https://help.heroku.com
-          remote:        
-          remote:        Thanks,
-          remote:        Heroku
+          remote:  !     
+          remote:  !     Please check your system.properties file to ensure the java.runtime.version
+          remote:  !     is among the list of supported version on the Dev Center:
+          remote:  !     https://devcenter.heroku.com/articles/java-support#supported-java-versions
+          remote:  !     You can also remove the system.properties from your repo to install
+          remote:  !     the default 21 version.
+          remote:  !     If you continue to have trouble, you can open a support ticket here:
+          remote:  !     https://help.heroku.com
+          remote:  !     
+          remote:  !     Thanks,
+          remote:  !     Heroku
           remote: 
           remote:  !     Push rejected, failed to compile JVM Common app.
         OUTPUT

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -85,4 +85,67 @@ RSpec.describe 'Java installation' do
       end
     end
   end
+
+  context 'when no OpenJDK version is specified on Heroku-24', stacks: %w[heroku-24] do
+    let(:app) { Hatchet::Runner.new('empty') }
+
+    it 'emits the correct warning' do
+      app.deploy do
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> JVM Common app detected
+          remote: 
+          remote:  !     WARNING: No OpenJDK version specified
+          remote:  !     
+          remote:  !     Your application does not explicitly specify an OpenJDK
+          remote:  !     version. The latest long-term support (LTS) version will be
+          remote:  !     installed. This currently is OpenJDK 21.
+          remote:  !     
+          remote:  !     This default version will change when a new LTS version is
+          remote:  !     released. Your application might fail to build with the new
+          remote:  !     version. We recommend explicitly setting the required OpenJDK
+          remote:  !     version for your application.
+          remote:  !     
+          remote:  !     To set the OpenJDK version, add or edit the system.properties
+          remote:  !     file in the root directory of your application to contain:
+          remote:  !     
+          remote:  !     java.runtime.version = 21
+          remote: 
+          remote: -----> Installing OpenJDK 21
+          remote: -----> Discovering process types
+          remote:        Procfile declares types -> (none)
+        OUTPUT
+      end
+    end
+  end
+
+  context 'when no OpenJDK version is specified on Heroku-20/Heroku-22', stacks: %w[heroku-20 heroku-22] do
+    let(:app) { Hatchet::Runner.new('empty') }
+
+    it 'emits the correct warning' do
+      app.deploy do
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> JVM Common app detected
+          remote: 
+          remote:  !     WARNING: No OpenJDK version specified
+          remote:  !     
+          remote:  !     Your application does not explicitly specify an OpenJDK
+          remote:  !     version. OpenJDK 1.8 will be installed.
+          remote:  !     
+          remote:  !     This default version will change at some point. Your
+          remote:  !     application might fail to build with the new version. We
+          remote:  !     recommend explicitly setting the required OpenJDK version for
+          remote:  !     your application.
+          remote:  !     
+          remote:  !     To set the OpenJDK version, add or edit the system.properties
+          remote:  !     file in the root directory of your application to contain:
+          remote:  !     
+          remote:  !     java.runtime.version = 1.8
+          remote: 
+          remote: -----> Installing OpenJDK 1.8
+          remote: -----> Discovering process types
+          remote:        Procfile declares types -> (none)
+        OUTPUT
+      end
+    end
+  end
 end

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -148,4 +148,37 @@ RSpec.describe 'Java installation' do
       end
     end
   end
+
+  context 'when an invalid OpenJDK version has been specified' do
+    let(:app) { Hatchet::Runner.new('empty', allow_failure: true) }
+
+    it 'fails the build with the correct error' do
+      app.before_deploy do
+        set_java_version(Dir.pwd, '.NET')
+      end
+
+      app.deploy do
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
+          remote: -----> JVM Common app detected
+          remote: -----> Installing OpenJDK .NET
+          remote: 
+          remote: 
+          remote:  !     ERROR: Unsupported Java version: .NET
+          remote:        
+          remote:        Please check your system.properties file to ensure the java.runtime.version
+          remote:        is among the list of supported version on the Dev Center:
+          remote:        https://devcenter.heroku.com/articles/java-support#supported-java-versions
+          remote:        You can also remove the system.properties from your repo to install
+          remote:        the default 21 version.
+          remote:        If you continue to have trouble, you can open a support ticket here:
+          remote:        https://help.heroku.com
+          remote:        
+          remote:        Thanks,
+          remote:        Heroku
+          remote: 
+          remote:  !     Push rejected, failed to compile JVM Common app.
+        OUTPUT
+      end
+    end
+  end
 end

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe 'Java installation' do
       end
 
       app.deploy do
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
           remote: -----> JVM Common app detected
           remote: -----> Installing OpenJDK .NET
           remote: 
@@ -168,7 +168,7 @@ RSpec.describe 'Java installation' do
           remote:  !     is among the list of supported version on the Dev Center:
           remote:  !     https://devcenter.heroku.com/articles/java-support#supported-java-versions
           remote:  !     You can also remove the system.properties from your repo to install
-          remote:  !     the default 21 version.
+          remote:  !     the default .+ version.
           remote:  !     If you continue to have trouble, you can open a support ticket here:
           remote:  !     https://help.heroku.com
           remote:  !     
@@ -176,7 +176,7 @@ RSpec.describe 'Java installation' do
           remote:  !     Heroku
           remote: 
           remote:  !     Push rejected, failed to compile JVM Common app.
-        OUTPUT
+        REGEX
       end
     end
   end

--- a/test/spec/overlay_spec.rb
+++ b/test/spec/overlay_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'JDK overlay' do
     app.deploy do
       expect(app.output).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
         remote: -----> JVM Common app detected        
-        remote: -----> Installing OpenJDK 8... done        
+        remote: -----> Installing OpenJDK 8        
       REGEX
 
       expect(app.run('cat .jdk/extra.txt')).to eq("extra.txt contents\n")
@@ -23,7 +23,7 @@ RSpec.describe 'JDK overlay' do
     app.deploy do
       expect(app.output).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
         remote: -----> JVM Common app detected        
-        remote: -----> Installing OpenJDK 21... done        
+        remote: -----> Installing OpenJDK 21        
       REGEX
 
       expect(app.run('cat .jdk/extra.txt')).to eq("extra.txt contents\n")

--- a/test/spec/spec_helper.rb
+++ b/test/spec/spec_helper.rb
@@ -43,3 +43,12 @@ def write_sys_props(directory, props)
     `git add system.properties && git commit -m "setting jdk version"`
   end
 end
+
+def clean_output(output)
+  output
+    # Remove trailing whitespace characters added by Git:
+    # https://github.com/heroku/hatchet/issues/162
+    .gsub(/ {8}(?=\R)/, '')
+    # Remove ANSI colour codes used in buildpack output (e.g. error messages).
+    .gsub(/\e\[[0-9;]+m/, '')
+end


### PR DESCRIPTION
Ports `output.sh` from the Python buildpack and changes all output to use the functions provided. Additional tests for correct output have also been added - they were initially used to verify the output is still correct and will continue to be part of the repository to catch regressions later.

The output slightly changes to be consistent with the Python buildpack, but nothing major.