### PR TITLE
Fix Hatchet app cleaner workflow

### DIFF
--- a/.github/workflows/hatchet_app_cleaner.yml
+++ b/.github/workflows/hatchet_app_cleaner.yml
@@ -24,7 +24,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: "2.7"
+          ruby-version: "3.3"
       - name: Run Hatchet destroy
         # Only apps older than 10 minutes are destroyed, to ensure that any
         # in progress CI runs are not interrupted.


### PR DESCRIPTION
The Hatchet app cleaner workflow is failing due to the Ruby version: 
https://github.com/heroku/heroku-buildpack-jvm-common/actions/runs/12972025143/job/36179040178#step:3:30
(I've been getting failure emails each time the cron runs)

This updates it to the same Ruby version used for the main Hatchet run after #325.