### PR TITLE
Implement `bin/report`

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -12,6 +12,14 @@ JVM_COMMON_DIR="${JVM_COMMON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ..
 source "${JVM_COMMON_DIR}/bin/util"
 # shellcheck source=bin/java
 source "${JVM_COMMON_DIR}/bin/java"
+# shellcheck source=lib/metadata.sh
+source "${JVM_COMMON_DIR}/lib/metadata.sh"
+
+# Initialise the buildpack metadata store.
+# This is used to track state across builds (for cache invalidation and messaging when build
+# configuration changes) and also so that `bin/report` can generate the build report.
+meta_init "${CACHE_DIR}" "jvm"
+meta_setup
 
 export_env_dir "${ENV_DIR}"
 

--- a/bin/java
+++ b/bin/java
@@ -183,7 +183,7 @@ install_java() {
 	cat <<-EOF >"${JVM_COMMON_BUILDPACK_DIR}/export"
 		export JAVA_HOME=${JAVA_HOME}
 		export PATH=\$JAVA_HOME/bin:\$PATH
-		export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:\$LD_LIBRARY_PATH"
+		export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:\${LD_LIBRARY_PATH:-}"
 	EOF
 
 	# Install an extension into the OpenJDK distribution extension folder should is exist. This will only

--- a/bin/report
+++ b/bin/report
@@ -17,4 +17,61 @@
 # issues check the internal build system logs for `buildpack.report.failed` events, or
 # when developing run `make run` in this repo locally, which runs `bin/report` too.
 
-# There is no reporting at this point in time. It will be implemented later.
+set -euo pipefail
+shopt -s inherit_errexit
+
+CACHE_DIR="${2}"
+
+# The absolute path to the root of the buildpack.
+JVM_COMMON_DIR="${JVM_COMMON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}"
+
+# The build system doesn't source the `export` script before running this script, so we have to do
+# so manually (if it exists) so that buildpack java can be found (if the build succeeded).
+EXPORT_FILE="${JVM_COMMON_DIR}/export"
+if [[ -f "${EXPORT_FILE}" ]]; then
+	# shellcheck source=/dev/null
+	source "${EXPORT_FILE}"
+fi
+
+source "${JVM_COMMON_DIR}/lib/metadata.sh"
+meta_init "${CACHE_DIR}" "jvm"
+
+# Emit the key / value pair unquoted to stdout. Skips if the value is empty.
+# Based on: https://github.com/heroku/heroku-buildpack-nodejs/blob/main/bin/report
+kv_pair() {
+	local key="${1}"
+	local value="${2}"
+	if [[ -n "${value}" ]]; then
+		echo "${key}: ${value}"
+	fi
+}
+
+# Emit the key / value pair to stdout, safely quoting the string. Skips if the value is empty.
+# Based on: https://github.com/heroku/heroku-buildpack-nodejs/blob/main/bin/report
+# (Though instead uses single quotes instead of double to avoid escaping issues.)
+kv_pair_string() {
+	local key="${1}"
+	local value="${2}"
+	if [[ -n "${value}" ]]; then
+		# Escape any existing single quotes, which for YAML means replacing `'` with `''`.
+		value="${value//\'/\'\'}"
+		echo "${key}: '${value}'"
+	fi
+}
+
+STRING_FIELDS=(
+)
+
+# We don't want to quote numeric or boolean fields.
+ALL_OTHER_FIELDS=(
+)
+
+for field in "${STRING_FIELDS[@]}"; do
+	# shellcheck disable=SC2312 # TODO: Invoke this command separately to avoid masking its return value.
+	kv_pair_string "${field}" "$(meta_get "${field}")"
+done
+
+for field in "${ALL_OTHER_FIELDS[@]}"; do
+	# shellcheck disable=SC2312 # TODO: Invoke this command separately to avoid masking its return value.
+	kv_pair "${field}" "$(meta_get "${field}")"
+done

--- a/lib/kvstore.sh
+++ b/lib/kvstore.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# This is technically redundant, since all consumers of this lib will have enabled these,
+# however, it helps Shellcheck realise the options under which these functions will run.
+set -euo pipefail
+
+# Taken from: https://github.com/heroku/heroku-buildpack-nodejs/blob/main/lib/kvstore.sh
+
+kv_create() {
+	local f="${1}"
+	mkdir -p "$(dirname "${f}")"
+	touch "${f}"
+}
+
+kv_clear() {
+	local f="${1}"
+	echo "" >"${f}"
+}
+
+kv_set() {
+	# TODO: Stop ignoring an incorrect number of passed arguments.
+	if [[ $# -eq 3 ]]; then
+		local f="${1}"
+		if [[ -f "${f}" ]]; then
+			echo "${2}=${3}" >>"${f}"
+		fi
+	fi
+}
+
+# Returns a key from the key-value store file, or else the empty string
+# if the file doesn't exist or the key wasn't found.
+kv_get() {
+	# TODO: Stop ignoring an incorrect number of passed arguments.
+	if [[ $# -eq 2 ]]; then
+		local f="${1}"
+		if [[ -f "${f}" ]]; then
+			# shellcheck disable=SC2310 # This function is invoked in an || condition so set -e will be disabled.
+			grep "^${2}=" "${f}" | sed -e "s/^${2}=//" | tail -n 1 || true
+		fi
+	fi
+}
+
+# get the value, but wrap it in quotes if it contains a space
+kv_get_escaped() {
+	local value
+	value=$(kv_get "${1}" "${2}")
+	if [[ "${value}" =~ [[:space:]]+ ]]; then
+		echo "\"${value}\""
+	else
+		echo "${value}"
+	fi
+}
+
+kv_keys() {
+	local f="${1}"
+	local keys=()
+
+	if [[ -f "${f}" ]]; then
+		# Iterate over each line, splitting on the '=' character
+		#
+		# The || [[ -n "${key}" ]] statement addresses an issue with reading the last line
+		# of a file when there is no newline at the end. This will not happen if the file
+		# is created with this module, but can happen if it is written by hand.
+		# See: https://stackoverflow.com/questions/12916352/shell-script-read-missing-last-line
+		while IFS="=" read -r key value || [[ -n "${key}" ]]; do
+			# if there are any empty lines in the store, skip them
+			if [[ -n "${key}" ]]; then
+				keys+=("${key}")
+			fi
+		done <"${f}"
+
+		echo "${keys[@]}" | tr ' ' '\n' | sort -u
+	fi
+}
+
+kv_list() {
+	local f="${1}"
+
+	kv_keys "${f}" | tr ' ' '\n' | while read -r key; do
+		if [[ -n "${key}" ]]; then
+			# shellcheck disable=SC2312 # TODO: Invoke this command separately to avoid masking its return value.
+			echo "${key}=$(kv_get_escaped "${f}" "${key}")"
+		fi
+	done
+}

--- a/lib/metadata.sh
+++ b/lib/metadata.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# This is technically redundant, since all consumers of this lib will have enabled these,
+# however, it helps Shellcheck realise the options under which these functions will run.
+set -euo pipefail
+
+# Based on: https://github.com/heroku/heroku-buildpack-nodejs/blob/main/lib/metadata.sh
+
+JVM_COMMON_DIR="${JVM_COMMON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)}"
+
+source "${JVM_COMMON_DIR:?}/lib/kvstore.sh"
+
+# Variables shared by this whole module
+BUILD_DATA_FILE=""
+PREVIOUS_BUILD_DATA_FILE=""
+
+# Must be called before you can use any other methods
+meta_init() {
+	local cache_dir="${1}"
+	local buildpack_name="${2}"
+	BUILD_DATA_FILE="${cache_dir}/build-data/${buildpack_name}"
+	PREVIOUS_BUILD_DATA_FILE="${cache_dir}/build-data/${buildpack_name}-prev"
+}
+
+# Moves the data from the last build into the correct place, and clears the store
+# This should be called after meta_init in bin/compile
+meta_setup() {
+	# if the file already exists because it's from the last build, save it
+	if [[ -f "${BUILD_DATA_FILE}" ]]; then
+		cp "${BUILD_DATA_FILE}" "${PREVIOUS_BUILD_DATA_FILE}"
+	fi
+
+	kv_create "${BUILD_DATA_FILE}"
+	kv_clear "${BUILD_DATA_FILE}"
+}
+
+# Force removal of exiting data file state. This is mostly useful during testing and not
+# expected to be used during buildpack execution.
+meta_force_clear() {
+	[[ -f "${BUILD_DATA_FILE}" ]] && rm "${BUILD_DATA_FILE}"
+	[[ -f "${PREVIOUS_BUILD_DATA_FILE}" ]] && rm "${PREVIOUS_BUILD_DATA_FILE}"
+}
+
+meta_get() {
+	kv_get "${BUILD_DATA_FILE}" "${1}"
+}
+
+meta_set() {
+	kv_set "${BUILD_DATA_FILE}" "${1}" "${2}"
+}
+
+# Similar to mtime from buildpack-stdlib
+meta_time() {
+	local key="${1}"
+	local start="${2}"
+	local end="${3:-$(nowms)}"
+	local time
+	time="$(echo "${start}" "${end}" | awk '{ printf "%.3f", ($2 - $1)/1000 }')"
+	kv_set "${BUILD_DATA_FILE}" "${key}" "${time}"
+}
+
+# Retrieve a value from a previous build if it exists
+# This is useful to give the user context about what changed if the
+# build has failed. Ex:
+#   - changed stacks
+#   - deployed with a new major version of Node
+#   - etc
+meta_prev_get() {
+	kv_get "${PREVIOUS_BUILD_DATA_FILE}" "${1}"
+}
+
+log_meta_data() {
+	# print all values on one line in logfmt format
+	# https://brandur.org/logfmt
+	# the echo call ensures that all values are printed on a single line
+	# shellcheck disable=SC2005,SC2046,SC2312
+	echo $(kv_list "${BUILD_DATA_FILE}")
+}


### PR DESCRIPTION
Bare bones implementation of `bin/report`, lifted from Heroku's Python buildpack and minimally adjusted. This PR does not add any metrics, those will be added in separate PRs later.