### PR TITLE
Refactor OpenJDK installation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Removed
+
+* Support for `JDK_URL_1_7`, `JDK_URL_1_8`, `JDK_URL_1_9`, `JDK_URL_10`, `JDK_URL_11`, `JDK_URL_12` environment variables to override OpenJDK download locations. (#000)
 
 ## [v159] - 2025-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Removed
 
-* Support for `JDK_URL_1_7`, `JDK_URL_1_8`, `JDK_URL_1_9`, `JDK_URL_10`, `JDK_URL_11`, `JDK_URL_12` environment variables to override OpenJDK download locations. (#000)
+* Support for `JDK_URL_1_7`, `JDK_URL_1_8`, `JDK_URL_1_9`, `JDK_URL_10`, `JDK_URL_11`, `JDK_URL_12` environment variables to override OpenJDK download locations. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339)
 
 ## [v159] - 2025-02-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Support for `JDK_URL_1_7`, `JDK_URL_1_8`, `JDK_URL_1_9`, `JDK_URL_10`, `JDK_URL_11`, `JDK_URL_12` environment variables to override OpenJDK download locations. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339)
 
+### Changed
+
+* The buildpack output will now explicitly mention the installed OpenJDK version instead of displaying only the major version. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339)
+
 ## [v159] - 2025-02-17
 
 ### Changed

--- a/bin/compile
+++ b/bin/compile
@@ -18,7 +18,7 @@ source "${JVM_COMMON_DIR}/lib/metadata.sh"
 # Initialise the buildpack metadata store.
 # This is used to track state across builds (for cache invalidation and messaging when build
 # configuration changes) and also so that `bin/report` can generate the build report.
-meta_init "${CACHE_DIR}" "jvm"
+meta_init "${CACHE_DIR}" "jvm-common"
 meta_setup
 
 export_env_dir "${ENV_DIR}"

--- a/bin/java
+++ b/bin/java
@@ -71,31 +71,28 @@ install_java_with_overlay() {
 		local jdkVersion
 		jdkVersion="$(java_properties::get "${buildDir}/system.properties" "java.runtime.version")"
 		jdkVersion="${jdkVersion:-${DEFAULT_JDK_VERSION}}"
+		jdkVersion=$(inventory::query "${jdkVersion}" "${STACK}" | jq -r '.version')
 
-		local jdkUrl
-		jdkUrl=$(_get_jdk_url_with_default "${jdkVersion}")
+		local jdkDistribution
+		jdkDistribution=$(inventory::query "${jdkVersion}" "${STACK}" | jq -r '.metadata.distribution')
 
-		_jvm_mcount "version.${jdkVersion}"
-		if [[ "$jdkVersion" == *openjdk* ]]; then
-			output::step "Installing Heroku OpenJDK $(_get_openjdk_version "${jdkVersion}")"
-			_jvm_mcount "vendor.openjdk"
-		elif [[ "$jdkVersion" == *heroku* ]]; then
-			output::step "Installing Heroku OpenJDK $(_get_heroku_version "${jdkVersion}")"
-			_jvm_mcount "vendor.openjdk"
-		elif [[ "$jdkVersion" == *zulu* ]]; then
-			output::step "Installing Azul Zulu OpenJDK $(_get_zulu_version "${jdkVersion}")"
-			_jvm_mcount "vendor.zulu"
-		else
-			output::step "Installing OpenJDK ${jdkVersion}"
-			_jvm_mcount "vendor.default"
-		fi
+		_conditional_meta_set "openjdk_version" "${jdkVersion}"
+		_conditional_meta_set "openjdk_distribution" "${jdkDistribution}"
 
-		install_java "${buildDir}" "${jdkVersion}" "${jdkUrl}"
+		local jdkName
+		case "${jdkDistribution}" in
+		"zulu") jdkName="Azul Zulu OpenJDK" ;;
+		"heroku") jdkName="Heroku OpenJDK" ;;
+		*) jdkName="OpenJDK" ;;
+		esac
+
+		output::step "Installing ${jdkName} ${jdkVersion}"
+
+		install_java "${buildDir}" "${jdkVersion}" "$(_get_jdk_url_with_default "${jdkVersion}")"
 		install_jdk_overlay "${buildDir}/.jdk" "${buildDir}"
 
 	else
 		output::step "Using provided JDK"
-		_jvm_mcount "vendor.provided"
 	fi
 }
 
@@ -263,18 +260,14 @@ _get_jdk_url_with_default() {
 	fi
 }
 
-_get_zulu_version() {
-	echo "${1//zulu-/}"
+# This file will be included by other buildpacks that might not have or might not have set up
+# the metadata file for reporting. To ensure we don't break those buildpacks but still be able to
+# set metadata about OpenJDK, we have wrapper functions that check for a proper setup first.
+
+_conditional_meta_set() {
+	if type -t meta_set >/dev/null; then meta_set "${1}" "${2}"; fi
 }
 
-_get_openjdk_version() {
-	echo "${1//openjdk-/}"
-}
-
-_get_heroku_version() {
-	echo "${1//heroku-/}"
-}
-
-_jvm_mcount() {
-	if type -t mcount >/dev/null; then mcount "jvm.${1}"; fi
+_conditional_meta_time() {
+	if type -t meta_time >/dev/null; then meta_time "${1}" "${2}"; fi
 }

--- a/bin/java
+++ b/bin/java
@@ -210,30 +210,6 @@ jdk_overlay() {
 
 # Internal functions
 
-# This function implements a legacy behavior in which the JDK_URL_1_8 or similar config var
-# could be used to override the URL to the JDK binary for a specific version. It's
-# not supported in the v3 implementation of the buildpack.
-_get_jdk_url_with_default() {
-	local jdkVersion="${1:?}"
-	if [ -n "${JDK_URL_1_7:-}" ] && { [ "$(expr "${jdkVersion}" : '^1.7')" != 0 ] || [ "$(expr "${jdkVersion}" : '^7')" != 0 ]; }; then
-		echo "$JDK_URL_1_7"
-	elif [ -n "${JDK_URL_1_8:-}" ] && { [ "$(expr "${jdkVersion}" : '^1.8')" != 0 ] || [ "$(expr "${jdkVersion}" : '^8')" != 0 ]; }; then
-		echo "$JDK_URL_1_8"
-	elif [ -n "${JDK_URL_1_9:-}" ] && { [ "$(expr "${jdkVersion}" : '^1.9')" != 0 ] || [ "$(expr "${jdkVersion}" : '^9')" != 0 ]; }; then
-		echo "$JDK_URL_1_9"
-	elif [ -n "${JDK_URL_10:-}" ] && [ "$(expr "${jdkVersion}" : '^10')" != 0 ]; then
-		echo "$JDK_URL_10"
-	elif [ -n "${JDK_URL_11:-}" ] && [ "$(expr "${jdkVersion}" : '^11')" != 0 ]; then
-		echo "$JDK_URL_11"
-	elif [ -n "${JDK_URL_12:-}" ] && [ "$(expr "${jdkVersion}" : '^12')" != 0 ]; then
-		echo "$JDK_URL_12"
-	elif [ -n "${JDK_URL_13:-}" ] && [ "$(expr "${jdkVersion}" : '^13')" != 0 ]; then
-		echo "$JDK_URL_13"
-	else
-		inventory::query "${jdkVersion}" "${STACK}" | jq -r ".url"
-	fi
-}
-
 # This file will be included by other buildpacks that might not have or might not have set up
 # the metadata file for reporting. To ensure we don't break those buildpacks but still be able to
 # set metadata about OpenJDK, we have wrapper functions that check for a proper setup first.

--- a/bin/java
+++ b/bin/java
@@ -27,6 +27,10 @@ install_java_with_overlay() {
 		_conditional_meta_time "openjdk_install_duration" "$(nowms)"
 
 		output::step "Using provided JDK"
+
+		# This will also skip installation of `.profile.d` scripts and other files. This is intentional to preserve
+		# historical behaviour. Since the provided JDK feature will be removed at some later point, there are no plans
+		# to change this behaviour.
 		return 0
 	fi
 

--- a/bin/java
+++ b/bin/java
@@ -126,15 +126,15 @@ install_java_with_overlay() {
 	mkdir "${openjdk_install_dir}"
 
 	# Download and extract OpenJDK distribution
-	local start_time
-	start_time=$(nowms)
+	local openjdk_install_start_time
+	openjdk_install_start_time=$(nowms)
 
 	local jdk_tarball="/tmp/jdk.tgz"
 	curl_with_defaults --retry 3 --silent --show-error --location "${openjdk_url}" --output "${jdk_tarball}"
 	tar -pxzf "${jdk_tarball}" -C "${openjdk_install_dir}"
 	rm "${jdk_tarball}"
 
-	_conditional_meta_time "openjdk_install_duration" "${start_time}"
+	_conditional_meta_time "openjdk_install_duration" "${openjdk_install_start_time}"
 
 	# Link base image Java keystore into the installed OpenJDK distribution, replacing the bundled
 	# certificates. Linking ensures that when the application image is rebased, the certificates are

--- a/bin/java
+++ b/bin/java
@@ -34,21 +34,22 @@ install_java_with_overlay() {
 		return 0
 	fi
 
-	local version_selection_string
-	version_selection_string="$(java_properties::get "${build_dir}/system.properties" "java.runtime.version")"
+	local openjdk_version_selector
+	openjdk_version_selector="$(java_properties::get "${build_dir}/system.properties" "java.runtime.version")"
+	_conditional_meta_set "openjdk_version_selector" "${openjdk_version_selector}"
 
-	if [ -z "${version_selection_string}" ]; then
+	if [ -z "${openjdk_version_selector}" ]; then
 		if [ "${STACK}" == "heroku-24" ]; then
 			# This should always be the latest OpenJDK LTS major version
 			# Next LTS will be OpenJDK 25 with a planned release date of 2025-09-16
-			version_selection_string="21"
+			openjdk_version_selector="21"
 
 			output::warning <<-EOF
 				WARNING: No OpenJDK version specified
 
 				Your application does not explicitly specify an OpenJDK
 				version. The latest long-term support (LTS) version will be
-				installed. This currently is OpenJDK ${version_selection_string}.
+				installed. This currently is OpenJDK ${openjdk_version_selector}.
 
 				This default version will change when a new LTS version is
 				released. Your application might fail to build with the new
@@ -58,16 +59,16 @@ install_java_with_overlay() {
 				To set the OpenJDK version, add or edit the system.properties
 				file in the root directory of your application to contain:
 
-				java.runtime.version = ${version_selection_string}
+				java.runtime.version = ${openjdk_version_selector}
 			EOF
 		else
-			version_selection_string="1.8"
+			openjdk_version_selector="1.8"
 
 			output::warning <<-EOF
 				WARNING: No OpenJDK version specified
 
 				Your application does not explicitly specify an OpenJDK
-				version. OpenJDK ${version_selection_string} will be installed.
+				version. OpenJDK ${openjdk_version_selector} will be installed.
 
 				This default version will change at some point. Your
 				application might fail to build with the new version. We
@@ -77,14 +78,14 @@ install_java_with_overlay() {
 				To set the OpenJDK version, add or edit the system.properties
 				file in the root directory of your application to contain:
 
-				java.runtime.version = ${version_selection_string}
+				java.runtime.version = ${openjdk_version_selector}
 			EOF
 		fi
 	fi
 
-	if ! openjdk_json=$(inventory::query "${version_selection_string}" "${STACK}"); then
+	if ! openjdk_json=$(inventory::query "${openjdk_version_selector}" "${STACK}"); then
 		output::error <<-EOF
-			ERROR: Unsupported Java version: ${version_selection_string}
+			ERROR: Unsupported Java version: ${openjdk_version_selector}
 
 			Please check your system.properties file to ensure the java.runtime.version
 			is among the list of supported version on the Dev Center:
@@ -184,35 +185,22 @@ install_java_with_overlay() {
 		curl_with_defaults --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
 	fi
 
-	local cacertPath="lib/security/cacerts"
+	# Apply the JDK overlay to the installed OpenJDK
+	if [[ -d "${build_dir}/.jdk-overlay/" ]]; then
+		_conditional_meta_set "app_contains_jdk_overlay" "true"
 
-	if [[ -d "${build_dir}/.jdk-overlay" ]]; then
-		# delete the symlink because a cp will error
-		if [ -f "${build_dir}/.jdk-overlay/jre/${cacertPath}" ] && [ -f "${openjdk_install_dir}/jre/${cacertPath}" ]; then
-			rm "${openjdk_install_dir}/jre/${cacertPath}"
-		elif [ -f "${build_dir}/.jdk-overlay/${cacertPath}" ] && [ -f "${openjdk_install_dir}/${cacertPath}" ]; then
-			rm "${openjdk_install_dir}/${cacertPath}"
-		fi
+		# Some symlinks need to be removed before the final cp command so that it doesn't fail.
+		for path in jre/lib/security/cacerts lib/security/cacerts; do
+			if [[ -f "${build_dir}/.jdk-overlay/${path}" ]] && [[ -f "${openjdk_install_dir}/${path}" ]]; then
+				rm "${openjdk_install_dir}/${path}"
+			fi
+		done
 
 		cp -r "${build_dir}/.jdk-overlay/"* "${openjdk_install_dir}"
+	else
+		_conditional_meta_set "app_contains_jdk_overlay" "false"
 	fi
 }
-
-# Legacy functions for backwards compatability
-detect_java_version() {
-	local jdkVersion
-	jdkVersion="$(java_properties::get "${1}/system.properties" "java.runtime.version")"
-	jdkVersion="${jdkVersion:${DEFAULT_VERSION_SELECTION_STRING}}"
-
-	echo "${jdkVersion}"
-}
-
-jdk_overlay() {
-	local buildDir="${1}"
-	install_jdk_overlay "${buildDir}/.jdk" "${buildDir}"
-}
-
-# Internal functions
 
 # This file will be included by other buildpacks that might not have or might not have set up
 # the metadata file for reporting. To ensure we don't break those buildpacks but still be able to

--- a/bin/java
+++ b/bin/java
@@ -10,14 +10,6 @@ JVM_COMMON_BUILDPACK_DIR="${JVM_COMMON_BUILDPACK_DIR:-$(cd "$(dirname "${BASH_SO
 # not be set. It should always default to the latest stack.
 STACK="${STACK:-"heroku-24"}"
 
-if [ "${STACK}" == "heroku-24" ]; then
-	# This should always be the latest OpenJDK LTS major version
-	# Next LTS will be OpenJDK 25 with a planned release date of 2025-09-16
-	DEFAULT_JDK_VERSION="21"
-else
-	DEFAULT_JDK_VERSION="1.8"
-fi
-
 # shellcheck source=lib/output.sh
 source "${JVM_COMMON_BUILDPACK_DIR}/lib/output.sh"
 # shellcheck source=lib/inventory.sh
@@ -26,142 +18,129 @@ source "${JVM_COMMON_BUILDPACK_DIR}/lib/inventory.sh"
 source "${JVM_COMMON_BUILDPACK_DIR}/lib/java_properties.sh"
 
 install_java_with_overlay() {
-	local buildDir="${1}"
+	local build_dir="${1}"
+	local openjdk_install_dir="${build_dir}/.jdk"
 
-	if [ ! -f "${buildDir}/.jdk/bin/java" ]; then
-		if [ -z "$(java_properties::get "${buildDir}/system.properties" "java.runtime.version")" ]; then
-			if [ "${STACK}" == "heroku-24" ]; then
-				output::warning <<-EOF
-					WARNING: No OpenJDK version specified
+	if [ -d "${openjdk_install_dir}" ]; then
+		_conditional_meta_set "openjdk_version" "provided"
+		_conditional_meta_set "openjdk_distribution" "provided"
+		_conditional_meta_time "openjdk_install_duration" "$(nowms)"
 
-					Your application does not explicitly specify an OpenJDK
-					version. The latest long-term support (LTS) version will be
-					installed. This currently is OpenJDK ${DEFAULT_JDK_VERSION}.
-
-					This default version will change when a new LTS version is
-					released. Your application might fail to build with the new
-					version. We recommend explicitly setting the required OpenJDK
-					version for your application.
-
-					To set the OpenJDK version, add or edit the system.properties
-					file in the root directory of your application to contain:
-
-					java.runtime.version = ${DEFAULT_JDK_VERSION}
-				EOF
-			else
-				output::warning <<-EOF
-					WARNING: No OpenJDK version specified
-
-					Your application does not explicitly specify an OpenJDK
-					version. OpenJDK ${DEFAULT_JDK_VERSION} will be installed.
-
-					This default version will change at some point. Your
-					application might fail to build with the new version. We
-					recommend explicitly setting the required OpenJDK version for
-					your application.
-
-					To set the OpenJDK version, add or edit the system.properties
-					file in the root directory of your application to contain:
-
-					java.runtime.version = ${DEFAULT_JDK_VERSION}
-				EOF
-			fi
-		fi
-
-		local jdkVersion
-		jdkVersion="$(java_properties::get "${buildDir}/system.properties" "java.runtime.version")"
-		jdkVersion="${jdkVersion:-${DEFAULT_JDK_VERSION}}"
-		jdkVersion=$(inventory::query "${jdkVersion}" "${STACK}" | jq -r '.version')
-
-		local jdkDistribution
-		jdkDistribution=$(inventory::query "${jdkVersion}" "${STACK}" | jq -r '.metadata.distribution')
-
-		_conditional_meta_set "openjdk_version" "${jdkVersion}"
-		_conditional_meta_set "openjdk_distribution" "${jdkDistribution}"
-
-		local jdkName
-		case "${jdkDistribution}" in
-		"zulu") jdkName="Azul Zulu OpenJDK" ;;
-		"heroku") jdkName="Heroku OpenJDK" ;;
-		*) jdkName="OpenJDK" ;;
-		esac
-
-		output::step "Installing ${jdkName} ${jdkVersion}"
-
-		install_java "${buildDir}" "${jdkVersion}" "$(_get_jdk_url_with_default "${jdkVersion}")"
-		install_jdk_overlay "${buildDir}/.jdk" "${buildDir}"
-
-	else
 		output::step "Using provided JDK"
+		return 0
 	fi
-}
 
-install_java() {
-	local build_dir=${1}
-	local jdkVersion="${2}"
-	local jdkUrl=${3:-$(_get_jdk_url_with_default "${jdkVersion}")}
+	local version_selection_string
+	version_selection_string="$(java_properties::get "${build_dir}/system.properties" "java.runtime.version")"
 
-	local jdkDir="${build_dir}"/.jdk
-	local javaExe="${jdkDir}/bin/java"
-	mkdir -p "${jdkDir}"
+	if [ -z "${version_selection_string}" ]; then
+		if [ "${STACK}" == "heroku-24" ]; then
+			# This should always be the latest OpenJDK LTS major version
+			# Next LTS will be OpenJDK 25 with a planned release date of 2025-09-16
+			version_selection_string="21"
 
-	if [ ! -f "${javaExe}" ] || is_java_version_change "${jdkDir}" "${jdkVersion}"; then
-		rm -rf "${jdkDir}"
-		mkdir -p "${jdkDir}"
+			output::warning <<-EOF
+				WARNING: No OpenJDK version specified
 
-		if [ "$(curl_with_defaults --retry 3 --silent --head -w "%{http_code}" -L "${jdkUrl}" -o /dev/null)" != "200" ]; then
-			output::error <<-EOF
-				ERROR: Unsupported Java version: ${jdkVersion}
+				Your application does not explicitly specify an OpenJDK
+				version. The latest long-term support (LTS) version will be
+				installed. This currently is OpenJDK ${version_selection_string}.
 
-				Please check your system.properties file to ensure the java.runtime.version
-				is among the list of supported version on the Dev Center:
-				https://devcenter.heroku.com/articles/java-support#supported-java-versions
-				You can also remove the system.properties from your repo to install
-				the default ${DEFAULT_JDK_VERSION} version.
-				If you continue to have trouble, you can open a support ticket here:
-				https://help.heroku.com
+				This default version will change when a new LTS version is
+				released. Your application might fail to build with the new
+				version. We recommend explicitly setting the required OpenJDK
+				version for your application.
 
-				Thanks,
-				Heroku
+				To set the OpenJDK version, add or edit the system.properties
+				file in the root directory of your application to contain:
+
+				java.runtime.version = ${version_selection_string}
 			EOF
+		else
+			version_selection_string="1.8"
 
-			return 1
-		fi
+			output::warning <<-EOF
+				WARNING: No OpenJDK version specified
 
-		# Download and extract OpenJDK distribution
-		local start_time
-		start_time=$(nowms)
+				Your application does not explicitly specify an OpenJDK
+				version. OpenJDK ${version_selection_string} will be installed.
 
-		local jdk_tarball="/tmp/jdk.tgz"
-		curl_with_defaults --retry 3 --silent --show-error --location "${jdkUrl}" --output "${jdk_tarball}"
-		tar -pxzf "${jdk_tarball}" -C "${jdkDir}"
-		rm "${jdk_tarball}"
+				This default version will change at some point. Your
+				application might fail to build with the new version. We
+				recommend explicitly setting the required OpenJDK version for
+				your application.
 
-		_conditional_meta_time "openjdk_install_duration" "${start_time}"
+				To set the OpenJDK version, add or edit the system.properties
+				file in the root directory of your application to contain:
 
-		# Link base image Java keystore into the installed OpenJDK distribution, replacing the bundled
-		# certificates. Linking ensures that when the application image is rebased, the certificates are
-		# updated for JVM applications, even though the OpenJDK distribution itself doesn't change.
-		if [ -f "${jdkDir}/jre/lib/security/cacerts" ] && [ -f "/etc/ssl/certs/java/cacerts" ]; then
-			mv "${jdkDir}/jre/lib/security/cacerts" "${jdkDir}/jre/lib/security/cacerts.old"
-			ln -s "/etc/ssl/certs/java/cacerts" "${jdkDir}/jre/lib/security/cacerts"
-		elif [ -f "${jdkDir}/lib/security/cacerts" ] && [ -f "/etc/ssl/certs/java/cacerts" ]; then
-			mv "${jdkDir}/lib/security/cacerts" "${jdkDir}/lib/security/cacerts.old"
-			ln -s "/etc/ssl/certs/java/cacerts" "${jdkDir}/lib/security/cacerts"
-		fi
-
-		echo "${jdkVersion}" >"${jdkDir}/version"
-		if [ ! -f "${javaExe}" ]; then
-			output::error <<-EOF
-				Unable to retrieve the JDK.
+				java.runtime.version = ${version_selection_string}
 			EOF
-
-			return 1
 		fi
 	fi
 
-	export JAVA_HOME=${jdkDir}
-	export PATH="${jdkDir}/bin:${PATH}"
+	if ! openjdk_json=$(inventory::query "${version_selection_string}" "${STACK}"); then
+		output::error <<-EOF
+			ERROR: Unsupported Java version: ${version_selection_string}
+
+			Please check your system.properties file to ensure the java.runtime.version
+			is among the list of supported version on the Dev Center:
+			https://devcenter.heroku.com/articles/java-support#supported-java-versions
+
+			If you continue to have trouble, you can open a support ticket here:
+			https://help.heroku.com
+
+			Thanks,
+			Heroku
+		EOF
+
+		return 1
+	fi
+
+	local openjdk_version
+	openjdk_version=$(jq -r '.version' <<<"${openjdk_json}")
+
+	local openjdk_distribution
+	openjdk_distribution=$(jq -r '.metadata.distribution' <<<"${openjdk_json}")
+
+	local openjdk_distribution_name
+	case "${openjdk_distribution}" in
+	"zulu") openjdk_distribution_name="Azul Zulu OpenJDK" ;;
+	"heroku") openjdk_distribution_name="Heroku OpenJDK" ;;
+	*) openjdk_distribution_name="OpenJDK" ;;
+	esac
+
+	local openjdk_url
+	openjdk_url=$(jq -r '.url' <<<"${openjdk_json}")
+
+	_conditional_meta_set "openjdk_version" "${openjdk_version}"
+	_conditional_meta_set "openjdk_distribution" "${openjdk_distribution}"
+
+	output::step "Installing ${openjdk_distribution_name} ${openjdk_version}"
+
+	rm -rf "${openjdk_install_dir}"
+	mkdir "${openjdk_install_dir}"
+
+	# Download and extract OpenJDK distribution
+	local start_time
+	start_time=$(nowms)
+
+	local jdk_tarball="/tmp/jdk.tgz"
+	curl_with_defaults --retry 3 --silent --show-error --location "${openjdk_url}" --output "${jdk_tarball}"
+	tar -pxzf "${jdk_tarball}" -C "${openjdk_install_dir}"
+	rm "${jdk_tarball}"
+
+	_conditional_meta_time "openjdk_install_duration" "${start_time}"
+
+	# Link base image Java keystore into the installed OpenJDK distribution, replacing the bundled
+	# certificates. Linking ensures that when the application image is rebased, the certificates are
+	# updated for JVM applications, even though the OpenJDK distribution itself doesn't change.
+	if [ -f "${openjdk_install_dir}/jre/lib/security/cacerts" ] && [ -f "/etc/ssl/certs/java/cacerts" ]; then
+		mv "${openjdk_install_dir}/jre/lib/security/cacerts" "${openjdk_install_dir}/jre/lib/security/cacerts.old"
+		ln -s "/etc/ssl/certs/java/cacerts" "${openjdk_install_dir}/jre/lib/security/cacerts"
+	elif [ -f "${openjdk_install_dir}/lib/security/cacerts" ] && [ -f "/etc/ssl/certs/java/cacerts" ]; then
+		mv "${openjdk_install_dir}/lib/security/cacerts" "${openjdk_install_dir}/lib/security/cacerts.old"
+		ln -s "/etc/ssl/certs/java/cacerts" "${openjdk_install_dir}/lib/security/cacerts"
+	fi
 
 	# Download Heroku JVM metrics agent JAR
 	mkdir -p "${build_dir}/.heroku/bin"
@@ -183,35 +162,43 @@ install_java() {
 	# Write export script for subsequent buildpacks to ensure they can use the installed OpenJDK.
 	# See: https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks
 	cat <<-EOF >"${JVM_COMMON_BUILDPACK_DIR}/export"
-		export JAVA_HOME=${JAVA_HOME}
+		export JAVA_HOME=${openjdk_install_dir}
 		export PATH=\$JAVA_HOME/bin:\$PATH
 		export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:\${LD_LIBRARY_PATH:-}"
 	EOF
 
+	# Source the export script manually here to ensure that other buildpacks that use this buildpack as a library
+	# also have the correct environment variables available.
+	# shellcheck source=/dev/null
+	source "${JVM_COMMON_BUILDPACK_DIR}/export"
+
 	# Install an extension into the OpenJDK distribution extension folder should is exist. This will only
 	# be the case for Java 8 as this OpenJDK feature was deprecated in 8u40.
 	# This JAR file sets `sslmode=require` for the postgres drivers.
-	local extDir="${JAVA_HOME}/jre/lib/ext"
+	local extDir="${openjdk_install_dir}/jre/lib/ext"
 	if [[ -d "${extDir}" ]] && [[ -z "${SKIP_PGCONFIG_INSTALL:-}" ]] && [[ "${CI:-}" != "true" ]]; then
 		curl_with_defaults --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
 	fi
-}
 
-is_java_version_change() {
-	jdkDir=$1
-	jdkVersion=${2:-${DEFAULT_JDK_VERSION}}
-	if [ ! -d "${jdkDir}" ]; then
-		echo "Invalid JDK directory."
-		return 1
+	local cacertPath="lib/security/cacerts"
+
+	if [[ -d "${build_dir}/.jdk-overlay" ]]; then
+		# delete the symlink because a cp will error
+		if [ -f "${build_dir}/.jdk-overlay/jre/${cacertPath}" ] && [ -f "${openjdk_install_dir}/jre/${cacertPath}" ]; then
+			rm "${openjdk_install_dir}/jre/${cacertPath}"
+		elif [ -f "${build_dir}/.jdk-overlay/${cacertPath}" ] && [ -f "${openjdk_install_dir}/${cacertPath}" ]; then
+			rm "${openjdk_install_dir}/${cacertPath}"
+		fi
+
+		cp -r "${build_dir}/.jdk-overlay/"* "${openjdk_install_dir}"
 	fi
-	test -f "${jdkDir}/version" && [ "$(cat "${jdkDir}/version")" != "${jdkVersion}" ]
 }
 
 # Legacy functions for backwards compatability
 detect_java_version() {
 	local jdkVersion
 	jdkVersion="$(java_properties::get "${1}/system.properties" "java.runtime.version")"
-	jdkVersion="${jdkVersion:${DEFAULT_JDK_VERSION}}"
+	jdkVersion="${jdkVersion:${DEFAULT_VERSION_SELECTION_STRING}}"
 
 	echo "${jdkVersion}"
 }
@@ -222,24 +209,6 @@ jdk_overlay() {
 }
 
 # Internal functions
-
-install_jdk_overlay() {
-	local jdkDir="${1:?}"
-	local appDir="${2:?}"
-	local cacertPath="lib/security/cacerts"
-	shopt -s dotglob
-
-	if [ -d "${jdkDir}" ] && [ -d "${appDir}/.jdk-overlay" ]; then
-		# delete the symlink because a cp will error
-		if [ -f "${appDir}/.jdk-overlay/jre/${cacertPath}" ] && [ -f "${jdkDir}/jre/${cacertPath}" ]; then
-			rm "${jdkDir}/jre/${cacertPath}"
-		elif [ -f "${appDir}/.jdk-overlay/${cacertPath}" ] && [ -f "${jdkDir}/${cacertPath}" ]; then
-			rm "${jdkDir}/${cacertPath}"
-		fi
-
-		cp -r "${appDir}/.jdk-overlay/"* "${jdkDir}"
-	fi
-}
 
 # This function implements a legacy behavior in which the JDK_URL_1_8 or similar config var
 # could be used to override the URL to the JDK binary for a specific version. It's

--- a/bin/java
+++ b/bin/java
@@ -180,9 +180,9 @@ install_java_with_overlay() {
 	# Install an extension into the OpenJDK distribution extension folder should is exist. This will only
 	# be the case for Java 8 as this OpenJDK feature was deprecated in 8u40.
 	# This JAR file sets `sslmode=require` for the postgres drivers.
-	local extDir="${openjdk_install_dir}/jre/lib/ext"
-	if [[ -d "${extDir}" ]] && [[ -z "${SKIP_PGCONFIG_INSTALL:-}" ]] && [[ "${CI:-}" != "true" ]]; then
-		curl_with_defaults --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${extDir}/pgconfig.jar"
+	local openjdk_jre_ext_dir="${openjdk_install_dir}/jre/lib/ext"
+	if [[ -d "${openjdk_jre_ext_dir}" ]] && [[ -z "${SKIP_PGCONFIG_INSTALL:-}" ]] && [[ "${CI:-}" != "true" ]]; then
+		curl_with_defaults --retry 3 -s -L "https://lang-jvm.s3.us-east-1.amazonaws.com/pgconfig.jar" -o "${openjdk_jre_ext_dir}/pgconfig.jar"
 	fi
 
 	# Apply the JDK overlay to the installed OpenJDK

--- a/bin/java
+++ b/bin/java
@@ -139,12 +139,13 @@ install_java_with_overlay() {
 	# Link base image Java keystore into the installed OpenJDK distribution, replacing the bundled
 	# certificates. Linking ensures that when the application image is rebased, the certificates are
 	# updated for JVM applications, even though the OpenJDK distribution itself doesn't change.
-	if [ -f "${openjdk_install_dir}/jre/lib/security/cacerts" ] && [ -f "/etc/ssl/certs/java/cacerts" ]; then
-		mv "${openjdk_install_dir}/jre/lib/security/cacerts" "${openjdk_install_dir}/jre/lib/security/cacerts.old"
-		ln -s "/etc/ssl/certs/java/cacerts" "${openjdk_install_dir}/jre/lib/security/cacerts"
-	elif [ -f "${openjdk_install_dir}/lib/security/cacerts" ] && [ -f "/etc/ssl/certs/java/cacerts" ]; then
-		mv "${openjdk_install_dir}/lib/security/cacerts" "${openjdk_install_dir}/lib/security/cacerts.old"
-		ln -s "/etc/ssl/certs/java/cacerts" "${openjdk_install_dir}/lib/security/cacerts"
+	if [[ -f "/etc/ssl/certs/java/cacerts" ]]; then
+		for path in "${openjdk_install_dir}/jre/lib/security/cacerts" "${openjdk_install_dir}/lib/security/cacerts"; do
+			if [[ -f "${path}" ]]; then
+				mv "${path}" "${path}.old"
+				ln -s "/etc/ssl/certs/java/cacerts" "${path}"
+			fi
+		done
 	fi
 
 	# Download Heroku JVM metrics agent JAR

--- a/bin/java
+++ b/bin/java
@@ -24,7 +24,6 @@ install_java_with_overlay() {
 	if [ -d "${openjdk_install_dir}" ]; then
 		_conditional_meta_set "openjdk_version" "provided"
 		_conditional_meta_set "openjdk_distribution" "provided"
-		_conditional_meta_time "openjdk_install_duration" "$(nowms)"
 
 		output::step "Using provided JDK"
 

--- a/bin/java
+++ b/bin/java
@@ -188,7 +188,7 @@ install_java_with_overlay() {
 
 	# Apply the JDK overlay to the installed OpenJDK
 	if [[ -d "${build_dir}/.jdk-overlay/" ]]; then
-		_conditional_meta_set "app_contains_jdk_overlay" "true"
+		_conditional_meta_set "app_has_jdk_overlay" "true"
 
 		# Some symlinks need to be removed before the final cp command so that it doesn't fail.
 		for path in jre/lib/security/cacerts lib/security/cacerts; do
@@ -199,7 +199,7 @@ install_java_with_overlay() {
 
 		cp -r "${build_dir}/.jdk-overlay/"* "${openjdk_install_dir}"
 	else
-		_conditional_meta_set "app_contains_jdk_overlay" "false"
+		_conditional_meta_set "app_has_jdk_overlay" "false"
 	fi
 }
 

--- a/bin/java
+++ b/bin/java
@@ -129,10 +129,15 @@ install_java() {
 		fi
 
 		# Download and extract OpenJDK distribution
+		local start_time
+		start_time=$(nowms)
+
 		local jdk_tarball="/tmp/jdk.tgz"
 		curl_with_defaults --retry 3 --silent --show-error --location "${jdkUrl}" --output "${jdk_tarball}"
 		tar -pxzf "${jdk_tarball}" -C "${jdkDir}"
 		rm "${jdk_tarball}"
+
+		_conditional_meta_time "openjdk_install_duration" "${start_time}"
 
 		# Link base image Java keystore into the installed OpenJDK distribution, replacing the bundled
 		# certificates. Linking ensures that when the application image is rebased, the certificates are

--- a/bin/report
+++ b/bin/report
@@ -68,7 +68,7 @@ STRING_FIELDS=(
 # We don't want to quote numeric or boolean fields.
 ALL_OTHER_FIELDS=(
 	openjdk_install_duration
-	app_contains_jdk_overlay
+	app_has_jdk_overlay
 )
 
 for field in "${STRING_FIELDS[@]}"; do

--- a/bin/report
+++ b/bin/report
@@ -66,7 +66,7 @@ STRING_FIELDS=(
 
 # We don't want to quote numeric or boolean fields.
 ALL_OTHER_FIELDS=(
-	openjdk_install_duration
+	#openjdk_install_duration
 )
 
 for field in "${STRING_FIELDS[@]}"; do

--- a/bin/report
+++ b/bin/report
@@ -60,10 +60,13 @@ kv_pair_string() {
 }
 
 STRING_FIELDS=(
+	openjdk_version
+	openjdk_distribution
 )
 
 # We don't want to quote numeric or boolean fields.
 ALL_OTHER_FIELDS=(
+	openjdk_install_duration
 )
 
 for field in "${STRING_FIELDS[@]}"; do

--- a/bin/report
+++ b/bin/report
@@ -62,11 +62,13 @@ kv_pair_string() {
 STRING_FIELDS=(
 	openjdk_version
 	openjdk_distribution
+	openjdk_version_selector
 )
 
 # We don't want to quote numeric or boolean fields.
 ALL_OTHER_FIELDS=(
 	openjdk_install_duration
+	app_contains_jdk_overlay
 )
 
 for field in "${STRING_FIELDS[@]}"; do

--- a/bin/report
+++ b/bin/report
@@ -66,7 +66,7 @@ STRING_FIELDS=(
 
 # We don't want to quote numeric or boolean fields.
 ALL_OTHER_FIELDS=(
-	#openjdk_install_duration
+	openjdk_install_duration
 )
 
 for field in "${STRING_FIELDS[@]}"; do

--- a/bin/util
+++ b/bin/util
@@ -111,3 +111,7 @@ curl_with_defaults() {
 
 	curl "${default_args[@]}" "${@}"
 }
+
+nowms() {
+	date +%s%3N
+}

--- a/lib/inventory.sh
+++ b/lib/inventory.sh
@@ -4,6 +4,8 @@ JVM_COMMON_DIR="${JVM_COMMON_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd ..
 
 # Query the OpenJDK inventory, returning an JSON object describing the release.
 #
+# Exits with a non-zero exit code if no matching OpenJDK release could be found.
+#
 # Usage:
 # ```
 # inventory::query "zulu-21" "heroku-20" | jq -r ".url"
@@ -25,6 +27,8 @@ inventory::query() {
 	INVENTORY_QUERY
 
 	jq <"${JVM_COMMON_DIR}/inventory.json" \
+		--exit-status \
+		--compact-output \
 		--arg raw_version_string "${raw_version_string}" \
 		--arg default_distribution "${default_distribution}" \
 		--arg stack "${stack}" \

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -97,13 +97,13 @@ RSpec.describe 'Java installation' do
 
     it 'emits the correct warning' do
       app.deploy do
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> JVM Common app detected
           remote: 
           remote:  !     WARNING: No OpenJDK version specified
           remote:  !     
           remote:  !     Your application does not explicitly specify an OpenJDK
-          remote:  !     version. The latest long-term support (LTS) version will be
+          remote:  !     version. The latest long-term support \\(LTS\\) version will be
           remote:  !     installed. This currently is OpenJDK 21.
           remote:  !     
           remote:  !     This default version will change when a new LTS version is
@@ -116,10 +116,10 @@ RSpec.describe 'Java installation' do
           remote:  !     
           remote:  !     java.runtime.version = 21
           remote: 
-          remote: -----> Installing OpenJDK 21
+          remote: -----> Installing Azul Zulu OpenJDK 21.0.[0-9]+
           remote: -----> Discovering process types
-          remote:        Procfile declares types -> (none)
-        OUTPUT
+          remote:        Procfile declares types -> \\(none\\)
+        REGEX
       end
     end
   end
@@ -129,7 +129,7 @@ RSpec.describe 'Java installation' do
 
     it 'emits the correct warning' do
       app.deploy do
-        expect(clean_output(app.output)).to include(<<~OUTPUT)
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> JVM Common app detected
           remote: 
           remote:  !     WARNING: No OpenJDK version specified
@@ -147,10 +147,10 @@ RSpec.describe 'Java installation' do
           remote:  !     
           remote:  !     java.runtime.version = 1.8
           remote: 
-          remote: -----> Installing OpenJDK 1.8
+          remote: -----> Installing .* OpenJDK 1.8.0_[0-9]+
           remote: -----> Discovering process types
-          remote:        Procfile declares types -> (none)
-        OUTPUT
+          remote:        Procfile declares types -> \\(none\\)
+        REGEX
       end
     end
   end
@@ -164,17 +164,15 @@ RSpec.describe 'Java installation' do
       end
 
       app.deploy do
-        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX))
+        expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> JVM Common app detected
-          remote: -----> Installing OpenJDK .NET
           remote: 
           remote:  !     ERROR: Unsupported Java version: .NET
           remote:  !     
           remote:  !     Please check your system.properties file to ensure the java.runtime.version
           remote:  !     is among the list of supported version on the Dev Center:
           remote:  !     https://devcenter.heroku.com/articles/java-support#supported-java-versions
-          remote:  !     You can also remove the system.properties from your repo to install
-          remote:  !     the default .+ version.
+          remote:  !     
           remote:  !     If you continue to have trouble, you can open a support ticket here:
           remote:  !     https://help.heroku.com
           remote:  !     
@@ -182,7 +180,7 @@ RSpec.describe 'Java installation' do
           remote:  !     Heroku
           remote: 
           remote:  !     Push rejected, failed to compile JVM Common app.
-        REGEX
+        OUTPUT
       end
     end
   end

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -2,47 +2,55 @@
 
 require_relative 'spec_helper'
 
+LATEST_HEROKU_OPENJDK_8_STRING = 'OpenJDK Runtime Environment (build 1.8.0_442-heroku-b06)'
+LATEST_HEROKU_OPENJDK_21_STRING = 'OpenJDK Runtime Environment (build 21.0.6+7)'
+LATEST_ZULU_OPENJDK_8_STRING = 'OpenJDK 64-Bit Server VM (Zulu 8.84.0.15-CA-linux64) (build 25.442-b06, mixed mode)'
+LATEST_ZULU_OPENJDK_11_STRING = 'OpenJDK Runtime Environment Zulu11.78+15-CA (build 11.0.26+4-LTS)'
+LATEST_ZULU_OPENJDK_17_STRING = 'OpenJDK Runtime Environment Zulu17.56+15-CA (build 17.0.14+7-LTS)'
+LATEST_ZULU_OPENJDK_21_STRING = 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)'
+LATEST_ZULU_OPENJDK_23_STRING = 'OpenJDK Runtime Environment Zulu23.32+11-CA (build 23.0.2+7)'
+
 EXPECTED_JAVA_VERSIONS = {
   'heroku-20' => {
-    nil => 'OpenJDK Runtime Environment (build 1.8.0_442-heroku-b06)',
-    '1.8' => 'OpenJDK Runtime Environment (build 1.8.0_442-heroku-b06)',
-    '8' => 'OpenJDK Runtime Environment (build 1.8.0_442-heroku-b06)',
+    nil => LATEST_HEROKU_OPENJDK_8_STRING,
+    '1.8' => LATEST_HEROKU_OPENJDK_8_STRING,
+    '8' => LATEST_HEROKU_OPENJDK_8_STRING,
     '11' => 'OpenJDK Runtime Environment (build 11.0.26+4)',
     '17' => 'OpenJDK Runtime Environment (build 17.0.14+7)',
-    '21' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
+    '21' => LATEST_HEROKU_OPENJDK_21_STRING,
     '23' => 'OpenJDK Runtime Environment (build 23.0.2+7)',
-    'heroku-21' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
-    'zulu-21' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    '21.0.6' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
-    'zulu-21.0.6' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
+    'heroku-21' => LATEST_HEROKU_OPENJDK_21_STRING,
+    'zulu-21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '21.0.6' => LATEST_HEROKU_OPENJDK_21_STRING,
+    'zulu-21.0.6' => LATEST_ZULU_OPENJDK_21_STRING,
   },
   'heroku-22' => {
-    nil => 'OpenJDK 64-Bit Server VM (Zulu 8.84.0.15-CA-linux64) (build 25.442-b06, mixed mode)',
-    '1.8' => 'OpenJDK 64-Bit Server VM (Zulu 8.84.0.15-CA-linux64) (build 25.442-b06, mixed mode)',
-    '8' => 'OpenJDK 64-Bit Server VM (Zulu 8.84.0.15-CA-linux64) (build 25.442-b06, mixed mode)',
-    '11' => 'OpenJDK Runtime Environment Zulu11.78+15-CA (build 11.0.26+4-LTS)',
-    '17' => 'OpenJDK Runtime Environment Zulu17.56+15-CA (build 17.0.14+7-LTS)',
-    '21' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    '23' => 'OpenJDK Runtime Environment Zulu23.32+11-CA (build 23.0.2+7)',
-    'heroku-21' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
-    'zulu-21' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    '21.0.6' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    'heroku-21.0.6' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
+    nil => LATEST_ZULU_OPENJDK_8_STRING,
+    '1.8' => LATEST_ZULU_OPENJDK_8_STRING,
+    '8' => LATEST_ZULU_OPENJDK_8_STRING,
+    '11' => LATEST_ZULU_OPENJDK_11_STRING,
+    '17' => LATEST_ZULU_OPENJDK_17_STRING,
+    '21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '23' => LATEST_ZULU_OPENJDK_23_STRING,
+    'heroku-21' => LATEST_HEROKU_OPENJDK_21_STRING,
+    'zulu-21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '21.0.6' => LATEST_ZULU_OPENJDK_21_STRING,
+    'heroku-21.0.6' => LATEST_HEROKU_OPENJDK_21_STRING,
   },
   'heroku-24' => {
-    nil => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    '1.8' => 'OpenJDK 64-Bit Server VM (Zulu 8.84.0.15-CA-linux64) (build 25.442-b06, mixed mode)',
-    '8' => 'OpenJDK 64-Bit Server VM (Zulu 8.84.0.15-CA-linux64) (build 25.442-b06, mixed mode)',
-    '11' => 'OpenJDK Runtime Environment Zulu11.78+15-CA (build 11.0.26+4-LTS)',
-    '17' => 'OpenJDK Runtime Environment Zulu17.56+15-CA (build 17.0.14+7-LTS)',
-    '21' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    '23' => 'OpenJDK Runtime Environment Zulu23.32+11-CA (build 23.0.2+7)',
-    'heroku-21' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
-    'zulu-21' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    '21.0.6' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
-    'heroku-21.0.6' => 'OpenJDK Runtime Environment (build 21.0.6+7)',
+    nil => LATEST_ZULU_OPENJDK_21_STRING,
+    '1.8' => LATEST_ZULU_OPENJDK_8_STRING,
+    '8' => LATEST_ZULU_OPENJDK_8_STRING,
+    '11' => LATEST_ZULU_OPENJDK_11_STRING,
+    '17' => LATEST_ZULU_OPENJDK_17_STRING,
+    '21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '23' => LATEST_ZULU_OPENJDK_23_STRING,
+    'heroku-21' => LATEST_HEROKU_OPENJDK_21_STRING,
+    'zulu-21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '21.0.6' => LATEST_ZULU_OPENJDK_21_STRING,
+    'heroku-21.0.6' => LATEST_HEROKU_OPENJDK_21_STRING,
     # Ensure that slightly incorrect version strings work
-    '    21 ' => 'OpenJDK Runtime Environment Zulu21.40+17-CA (build 21.0.6+7-LTS)',
+    '    21 ' => LATEST_ZULU_OPENJDK_21_STRING,
   },
 }.freeze
 

--- a/test/spec/overlay_spec.rb
+++ b/test/spec/overlay_spec.rb
@@ -7,9 +7,9 @@ RSpec.describe 'JDK overlay' do
     app = Hatchet::Runner.new('jdk-overlay-java-8')
 
     app.deploy do
-      expect(app.output).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
-        remote: -----> JVM Common app detected        
-        remote: -----> Installing OpenJDK 8        
+      expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+        remote: -----> JVM Common app detected
+        remote: -----> Installing .* OpenJDK 1.8.0_[0-9]+
       REGEX
 
       expect(app.run('cat .jdk/extra.txt')).to eq("extra.txt contents\n")
@@ -21,9 +21,9 @@ RSpec.describe 'JDK overlay' do
     app = Hatchet::Runner.new('jdk-overlay')
 
     app.deploy do
-      expect(app.output).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
-        remote: -----> JVM Common app detected        
-        remote: -----> Installing OpenJDK 21        
+      expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+        remote: -----> JVM Common app detected
+        remote: -----> Installing .* OpenJDK 21.0.[0-9]+
       REGEX
 
       expect(app.run('cat .jdk/extra.txt')).to eq("extra.txt contents\n")


### PR DESCRIPTION
Refactors the OpenJDK installation code to make it simpler and more correct. At the same time, it adds metrics for some of the obvious things that we need such as installed version selector, installed OpenJDK version and distribution and installation duration.

This PR improves the version reporting so that it uses the canonical version and distribution name from the inventory, rather than the string that is supplied by the user. That string is now solely used to get the correct version from the inventory and for setting the default version. The buildpack can now also correctly log the installed version and the distribution.

Another improvement is around reporting of missing versions. If the requested version cannot be found in the inventory, the buildpack will report the version as missing. Before, an HTTP request was made to determine if the file existed (which sometimes was just an empty string).