### PR TITLE
Use explicit host buildpack directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,19 @@
 
 ## [Unreleased]
 
+### Changed
+
+* Deprecated `install_java_with_overlay` function. Buildpacks using this function should now use `install_openjdk` instead. See `README.md` for a usage example. ([#346](https://github.com/heroku/heroku-buildpack-jvm-common/pull/346))
 
 ## [v160] - 2025-02-19
 
 ### Removed
 
-* Support for `JDK_URL_1_7`, `JDK_URL_1_8`, `JDK_URL_1_9`, `JDK_URL_10`, `JDK_URL_11`, `JDK_URL_12` environment variables to override OpenJDK download locations. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339)
+* Support for `JDK_URL_1_7`, `JDK_URL_1_8`, `JDK_URL_1_9`, `JDK_URL_10`, `JDK_URL_11`, `JDK_URL_12` environment variables to override OpenJDK download locations. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339))
 
 ### Changed
 
-* The buildpack output will now explicitly mention the installed OpenJDK version instead of displaying only the major version. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339)
+* The buildpack output will now explicitly mention the installed OpenJDK version instead of displaying only the major version. ([#339](https://github.com/heroku/heroku-buildpack-jvm-common/pull/339))
 
 ## [v159] - 2025-02-17
 

--- a/README.md
+++ b/README.md
@@ -7,13 +7,17 @@ This is the official [Heroku buildpack](https://devcenter.heroku.com/articles/bu
 This is how the buildpack is used from another buildpack:
 
 ```bash
+# Determine the root directory of your own buildpack. For example:
+BUILDPACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+
 JVM_BUILDPACK_URL="https://buildpack-registry.s3.us-east-1.amazonaws.com/buildpacks/heroku/jvm.tgz"
+
 mkdir -p /tmp/jvm-common
 curl --silent --fail --retry 3 --retry-connrefused --connect-timeout 5 --location $JVM_BUILDPACK_URL | tar xzm -C /tmp/jvm-common --strip-components=1
 source /tmp/jvm-common/bin/util
 source /tmp/jvm-common/bin/java
 
-install_java_with_overlay ${BUILD_DIR}
+install_openjdk "${BUILD_DIR}" "${BUILDPACK_DIR}"
 ```
 
 ## Standalone Usage

--- a/bin/compile
+++ b/bin/compile
@@ -23,4 +23,4 @@ meta_setup
 
 export_env_dir "${ENV_DIR}"
 
-install_java_with_overlay "${BUILD_DIR}" "${CACHE_DIR}"
+install_openjdk "${BUILD_DIR}" "${JVM_COMMON_DIR}"

--- a/bin/java
+++ b/bin/java
@@ -17,8 +17,11 @@ source "${JVM_COMMON_BUILDPACK_DIR}/lib/inventory.sh"
 # shellcheck source=lib/java_properties.sh
 source "${JVM_COMMON_BUILDPACK_DIR}/lib/java_properties.sh"
 
-install_java_with_overlay() {
+install_openjdk() {
 	local build_dir="${1}"
+	# Root directory of the buildpack that invoked this function
+	local host_buildpack_dir="${2}"
+
 	local openjdk_install_dir="${build_dir}/.jdk"
 
 	if [ -d "${openjdk_install_dir}" ]; then
@@ -165,17 +168,20 @@ install_java_with_overlay() {
 	cp -r "${JVM_COMMON_BUILDPACK_DIR}/opt/tools/"* "${build_dir}/.heroku"
 
 	# Write export script for subsequent buildpacks to ensure they can use the installed OpenJDK.
+	# Note that this is not using JVM_COMMON_BUILDPACK_DIR but the directory of the buildpack that
+	# invoked this function to write it to the correct location.
+	#
 	# See: https://devcenter.heroku.com/articles/buildpack-api#composing-multiple-buildpacks
-	cat <<-EOF >"${JVM_COMMON_BUILDPACK_DIR}/export"
+	cat <<-EOF >>"${host_buildpack_dir}/export"
 		export JAVA_HOME=${openjdk_install_dir}
 		export PATH=\$JAVA_HOME/bin:\$PATH
-		export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server:\${LD_LIBRARY_PATH:-}"
+		export LD_LIBRARY_PATH="\$JAVA_HOME/jre/lib/amd64/server\${LD_LIBRARY_PATH:+:}\${LD_LIBRARY_PATH:-}"
 	EOF
 
 	# Source the export script manually here to ensure that other buildpacks that use this buildpack as a library
 	# also have the correct environment variables available.
 	# shellcheck source=/dev/null
-	source "${JVM_COMMON_BUILDPACK_DIR}/export"
+	source "${host_buildpack_dir}/export"
 
 	# Install an extension into the OpenJDK distribution extension folder should is exist. This will only
 	# be the case for Java 8 as this OpenJDK feature was deprecated in 8u40.
@@ -200,6 +206,22 @@ install_java_with_overlay() {
 	else
 		_conditional_meta_set "app_has_jdk_overlay" "false"
 	fi
+}
+
+# Deprecated legacy function to install OpenJDK, we're keeping it around to not break
+# existing buildpacks that use it. If you're implementing a new buildpack, do not use
+# this function.
+install_java_with_overlay() {
+	local build_dir="${1}"
+
+	# The old API expected the cache directory as the second argument.
+	# We're explicitly spelling this out here for documentation purposes,
+	# but it's not used by the new OpenJDK installation function.
+	# shellcheck disable=SC2034
+	local cache_dir="${2}"
+
+	# The old function didn't use an explicit buildpack directory but used the current working directory instead.
+	install_openjdk "${build_dir}" "$(pwd)"
 }
 
 # This file will be included by other buildpacks that might not have or might not have set up


### PR DESCRIPTION
The export script is currently written to the directory of the JVM common buildpack. This works fine when the JVM common buildpack is used standalone. But it will cause the export script to not be used by subsequent buildpacks when `install_java_with_overlay` is used from another buildpack like `heroku/java`.

To fix this, we need to pass the directory of the host buildpack so we can build the correct path to the export script. However, since `install_java_with_overlay` is used by other buildpacks that use a slightly different API where the second argument is the cache directory, we cannot add that host buildpack argument as the second argument to the function.

This PR renames the `install_java_with_overlay` function to `install_openjdk` which can use a new API. A new `install_java_with_overlay` was added that serves as a bridge between the legacy and new API so that existing buildpacks won't break.