### PR TITLE
Output error when legacy functions are used

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -233,3 +233,6 @@ _conditional_meta_set() {
 _conditional_meta_time() {
 	if type -t meta_time >/dev/null; then meta_time "${1}" "${2}"; fi
 }
+
+source "${JVM_COMMON_BUILDPACK_DIR}/lib/legacy.sh"
+legacy::install_removed_function_handler install_java validate_jdk_url is_java_version_change detect_java_version jdk_overlay

--- a/bin/util
+++ b/bin/util
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+JVM_COMMON_BUILDPACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+
 # While these logging/output functions seem unused, they are used by downstream buildpacks that source this file.
 # Do not delete them before making sure that all known downstream buildpacks do not use these anymore.
 
@@ -60,3 +62,6 @@ indent() {
 	*) sed -u "$c" ;;      # unix/gnu sed: -u unbuffered (arbitrary) chunks of data
 	esac
 }
+
+source "${JVM_COMMON_BUILDPACK_DIR}/lib/legacy.sh"
+legacy::install_removed_function_handler curl_with_defaults copy_directories export_env_dir nowms

--- a/lib/legacy.sh
+++ b/lib/legacy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+JVM_COMMON_BUILDPACK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && cd .. && pwd)"
+
+source "${JVM_COMMON_BUILDPACK_DIR}/lib/output.sh"
+
+# This buildpack did undergo significant changes in 2025. Some internal functions were removed that might be used
+# by other buildpacks that use this buildpack as a library. To make their experience less painful, we output an error
+# message about this change and exit the shell if one of those functions are being used.
+legacy::install_removed_function_handler() {
+	for removed_function_name in "${@}"; do
+		# Avoid installing the handler if the downstream code defined their own function of the same name
+		if ! [[ $(type -t "${removed_function_name}") == function ]]; then
+			eval "${removed_function_name}() { legacy::removed_handler \"${removed_function_name}\"; }"
+		fi
+	done
+}
+
+legacy::removed_handler() {
+	function_name="${1}"
+
+	output::error <<-EOF
+		ERROR: Function ${function_name} no longer exposed
+
+		The buildpack you're using is likely employing Heroku's jvm-common
+		buildpack to install OpenJDK.
+
+		Your buildpack is using the bash function ${function_name} which is no
+		longer exposed in the latest release of Heroku's jvm-common buildpack.
+		If you didn't upgrade anything, it's likely that your buildpack is
+		implicitly using the latest release of Heroku's jvm-common buildpack.
+
+		Your buildpack needs changes to continue to work. In most cases
+
+		install_openjdk "\${BUILD_DIR}" "\${BUILDPACK_DIR}"
+
+		should be sufficient to install OpenJDK. Please refer to jvm-commons
+		README.md file for a complete usage example:
+
+		https://github.com/heroku/heroku-buildpack-jvm-common
+	EOF
+
+	exit 1
+}

--- a/lib/legacy.sh
+++ b/lib/legacy.sh
@@ -34,7 +34,7 @@ legacy::removed_handler() {
 
 		install_openjdk "\${BUILD_DIR}" "\${BUILDPACK_DIR}"
 
-		should be sufficient to install OpenJDK. Please refer to jvm-commons
+		should be sufficient to install OpenJDK. Please refer to jvm-common's
 		README.md file for a complete usage example:
 
 		https://github.com/heroku/heroku-buildpack-jvm-common

--- a/lib/legacy.sh
+++ b/lib/legacy.sh
@@ -8,6 +8,7 @@ source "${JVM_COMMON_BUILDPACK_DIR}/lib/output.sh"
 # by other buildpacks that use this buildpack as a library. To make their experience less painful, we output an error
 # message about this change and exit the shell if one of those functions are being used.
 legacy::install_removed_function_handler() {
+	local removed_function_name
 	for removed_function_name in "${@}"; do
 		# Avoid installing the handler if the downstream code defined their own function of the same name
 		if ! [[ $(type -t "${removed_function_name}") == function ]]; then
@@ -17,7 +18,7 @@ legacy::install_removed_function_handler() {
 }
 
 legacy::removed_handler() {
-	function_name="${1}"
+	local function_name="${1}"
 
 	output::error <<-EOF
 		ERROR: Function ${function_name} no longer exposed


### PR DESCRIPTION
The broad refactoring of this buildpack removed some functions that were used by other buildpacks, even when they were not intended to be used by them. In such cases, debugging the issue downstream is harder than it should be. This PR introduces an error message that will explain what happened and how to fix the issue.

See: https://github.com/heroku/heroku-buildpack-jvm-common/issues/343