### PR TITLE
Add `inventory.json` validation in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Determine if inventory.json changed
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46.0.5
         id: changed-files
         with:
           files: inventory.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,3 +82,49 @@ jobs:
         run: make run
       #- name: Run buildpack using an app fixture that's expected to fail
       #  run: make run FIXTURE=spec/fixtures/failing/
+
+  validate-inventory:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Determine if inventory.json changed
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
+        id: changed-files
+        with:
+          files: inventory.json
+      - name: Validate inventory.json contents
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: |
+          set -euo pipefail
+
+          artifacts=$(cat inventory.json | jq -c -r '.artifacts[]')
+
+          for artifact in $artifacts; do
+            url=$(echo "${artifact}" | jq -r '.url')
+
+            # This script assumes the usage of SHA256 as the digest as we currently only use SHA256
+            # in JVM inventory files. Should this ever change, this script will fail with a checksum
+            # error, but will not let unknown digests pass silently. This makes it a safe assumption and
+            # simplifies the script.
+            sha256_checksum=$(echo "${artifact}" | jq -r '.checksum[7:]')
+
+            echo -n "${url}... "
+
+            temp_file=$(mktemp)
+
+            if ! curl --silent --fail -o "${temp_file}" "${url}"; then
+              echo "DOWNLOAD ERROR"
+              exit 1
+            fi
+
+            actual_sha256_checksum=$(shasum -a256 "${temp_file}" | cut -d' ' -f1)
+            if [[ "${actual_sha256_checksum}" == "${sha256_checksum}" ]]; then
+              echo "OK"
+            else
+              echo "CHECKSUM ERROR"
+              exit 1
+            fi
+
+            rm "${temp_file}"
+          done


### PR DESCRIPTION
Integration and unit tests cannot reasonably cover all available OpenJDK versions referenced in the inventory file. However, a correct inventory file is crucial. This PR adds a GHA CI job that runs when the inventory file changed which downloads all referenced files and validates their checksums.

This process takes a while (last trail run took ~15 minutes), but inventory file changes are rare since there are only ~6 OpenJDK release batches per year and the check only runs if the inventory file actually changed.

[GUS-W-18247614](https://gus.lightning.force.com/a07EE00002CTs6vYAD)