### PR TITLE
Limit JAVA_TOOL_OPTIONS logging

### DIFF
--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -59,7 +59,10 @@ jvm_options() {
 jvm_options="$(jvm_options)"
 export JAVA_OPTS="${jvm_options}${JAVA_OPTS:+" "}${JAVA_OPTS:-}"
 
+# Only display log output for web dynos to prevent breaking one-off dyno scripting and MCP server use-cases.
+if [[ "${DYNO:-}" == web.* ]]; then
+	echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them." >&2
+fi
 if ! [[ "${DYNO}" =~ ^run\..*$ ]]; then
-	echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them."
 	export JAVA_TOOL_OPTIONS="${jvm_options}${JAVA_TOOL_OPTIONS:+" "}${JAVA_TOOL_OPTIONS:-}"
 fi


### PR DESCRIPTION
Folks developing [custom MCP servers on Heroku](https://devcenter.heroku.com/articles/heroku-inference-working-with-mcp) are encountering issues with a log message from this buildpack:

```
failed to send initialize request: Received unexpected content: Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them.
```

MCP servers using the stdio transport are expected to output only JSONL content to stdout. Logging content on stdout at startup breaks that expectation.

I've made two changes to help alleviate this problem:

1. Send the log message to stderr. Heroku's MCP integration ignores stderr output. Additionally, this message seems more appropriate for stderr.
2. Only log this message from `web` dynos. This is the approach the python buildpack uses [here](https://github.com/heroku/heroku-buildpack-python/blob/e094206515982668fab6e33896651279254b27fc/vendor/WEB_CONCURRENCY.sh#L46-L51).

Either of these approaches should fix the issue. I've included both. Feel free to edit/change this PR if you want only one of the above.


[Heroku AI GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002JFU8OYAX/view)
