### PR TITLE
Use stderr for `JAVA_TOOL_OPTIONS` message

### DIFF
--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -60,6 +60,8 @@ jvm_options="$(jvm_options)"
 export JAVA_OPTS="${jvm_options}${JAVA_OPTS:+" "}${JAVA_OPTS:-}"
 
 if ! [[ "${DYNO}" =~ ^run\..*$ ]]; then
-	echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them."
+	# Redirecting to stderr to avoid polluting the application's stdout stream. This is especially important for
+	# MCP servers using the stdio transport: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
+	echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them." >&2
 	export JAVA_TOOL_OPTIONS="${jvm_options}${JAVA_TOOL_OPTIONS:+" "}${JAVA_TOOL_OPTIONS:-}"
 fi


### PR DESCRIPTION
Java MCP servers using the stdio transport are failing because the buildpack logs a message about JAVA_TOOL_OPTIONS defaults to stdout. MCP stdio servers expect only JSONL data on stdout, and any additional output breaks the protocol communication.

The message "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them." is currently written to stdout in non-run dynos, polluting the stdout stream that MCP servers rely on.

This change redirects the logging to stderr using `>&2`, preserving the debugging information while keeping stdout clean for applications that require it. This fixes Java MCP server compatibility without breaking existing functionality.

Reference: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio

Supersedes #378 
GUS-W-19174228
