### PR TITLE
Don't log JAVA_TOOL_OPTIONS message on mcp* process types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [Unreleased]
 
+* Do not log JAVA_TOOL_OPTIONS messages on MCP servers. ([#382](https://github.com/heroku/heroku-buildpack-jvm-common/pull/382))
 
 ## [v167] - 2025-07-31
 

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -61,7 +61,7 @@ export JAVA_OPTS="${jvm_options}${JAVA_OPTS:+" "}${JAVA_OPTS:-}"
 
 if ! [[ "${DYNO}" =~ ^run\..*$ ]]; then
 	# Avoid logging this message on MCP servers to prevent polluting the application's output.
-	# This is especially important for MCP servers using the stdio transport: 
+	# This is especially important for MCP servers using the stdio transport:
 	# https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
 	if ! [[ "${DYNO}" =~ ^mcp.*$ ]]; then
 		echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them." >&2

--- a/opt/jvmcommon.sh
+++ b/opt/jvmcommon.sh
@@ -60,8 +60,11 @@ jvm_options="$(jvm_options)"
 export JAVA_OPTS="${jvm_options}${JAVA_OPTS:+" "}${JAVA_OPTS:-}"
 
 if ! [[ "${DYNO}" =~ ^run\..*$ ]]; then
-	# Redirecting to stderr to avoid polluting the application's stdout stream. This is especially important for
-	# MCP servers using the stdio transport: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
-	echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them." >&2
+	# Avoid logging this message on MCP servers to prevent polluting the application's output.
+	# This is especially important for MCP servers using the stdio transport: 
+	# https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio
+	if ! [[ "${DYNO}" =~ ^mcp.*$ ]]; then
+		echo "Setting JAVA_TOOL_OPTIONS defaults based on dyno size. Custom settings will override them." >&2
+	fi
 	export JAVA_TOOL_OPTIONS="${jvm_options}${JAVA_TOOL_OPTIONS:+" "}${JAVA_TOOL_OPTIONS:-}"
 fi

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -45,7 +45,7 @@ EXPECTED_JAVA_VERSIONS = {
 # to validate they were properly installed. However, This is not a
 # replacement for testing their functionality in dedicated tests!
 FILE_MD5_HASHES = {
-  '.profile.d/jvmcommon.sh' => 'f9b1d2b06dfa5f745edc834df4619ed7',
+  '.profile.d/jvmcommon.sh' => '3a0ba7b9d8e613c856c85bd749f7ddd1',
   '.profile.d/default-proc-warning.sh' => 'bb7cd4e1747e2a0c0e9a7137e84d3cf5',
   '.profile.d/heroku-jvm-metrics.sh' => '9f48b384bc3d9161e45e15906793b191',
   '.profile.d/jdbc.sh' => '7a2abf4a9aaec0b98e3681fbc2d4d215',


### PR DESCRIPTION
This is a follow-up to #379 and #378. In #379, we redirected this output message to stderr to avoid polluting the stdout stream. While that goal was achieved, the problem still exists when connecting to the dyno over Rendezvous. Rendezvous streams include both stdout AND stderr, so any logging (even on stdout) can still pollute the JSONL output.

This PR further restricts the log message so that it's not printed for `mcp*` servers.

[Heroku AI GUS WI](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002JG9zeYAD/view)