### PR TITLE
Fix `java_properties::get` error handling

### DIFF
--- a/lib/java_properties.sh
+++ b/lib/java_properties.sh
@@ -1,21 +1,24 @@
 #!/usr/bin/env bash
 
+# This is technically redundant, since all consumers of this lib will have enabled these,
+# however, it helps Shellcheck realise the options under which these functions will run.
+set -euo pipefail
+
 # Reads the value of a key from a Java properties file
 #
 # ```
 # java_properties:get "system.properties" "java.runtime.version"
 # ```
-java_properties::get() {
+function java_properties::get() {
 	local file=${1:?}
 	local key=${2:?}
 
-	if [ -f "${file}" ]; then
-		local escaped_key
-		escaped_key="${key//\./\\.}"
+	local escaped_key
+	escaped_key="${key//\./\\.}"
 
-		grep -E "^${escaped_key}[[:space:]=]+" "${file}" |
-			sed -E -e "s/${escaped_key}([\ \t]*=[\ \t]*|[\ \t]+)([_A-Za-z0-9\.-]*).*/\2/g"
-	else
-		echo ""
-	fi
+	# Allow grep to fail (via `true`) for handling the case where the file or key is not found.
+	local grep_result
+	grep_result=$(grep -E "^${escaped_key}[[:space:]=]+" "${file}" || true)
+
+	echo "${grep_result}" | sed -E -e "s/${escaped_key}([\ \t]*=[\ \t]*|[\ \t]+)([_A-Za-z0-9\.-]*).*/\2/g"
 }

--- a/lib/java_properties.sh
+++ b/lib/java_properties.sh
@@ -2,7 +2,9 @@
 
 # This is technically redundant, since all consumers of this lib will have enabled these,
 # however, it helps Shellcheck realise the options under which these functions will run.
-set -euo pipefail
+# Temporarily commented out since not all downstream buildpacks that are sourcing the files of
+# this buildpack work with these settings yet.
+# set -euo pipefail
 
 # Reads the value of a key from a Java properties file
 #
@@ -18,7 +20,7 @@ function java_properties::get() {
 
 	# Allow grep to fail (via `true`) for handling the case where the file or key is not found.
 	local grep_result
-	grep_result=$(grep -E "^${escaped_key}[[:space:]=]+" "${file}" || true)
+	grep_result=$(grep -E "^${escaped_key}[[:space:]=]+" "${file}" 2>/dev/null || true)
 
 	echo "${grep_result}" | sed -E -e "s/${escaped_key}([\ \t]*=[\ \t]*|[\ \t]+)([_A-Za-z0-9\.-]*).*/\2/g"
 }


### PR DESCRIPTION
Fix `java_properties::get` error handling. It was previously exiting the script under `set -euo pipefail` when the key didn't exist. Downstream buildpacks might have these settings enabled (and this buildpack eventually too).

GUS-W-19476048