### PR TITLE
Standardize warning and error message formatting

### DIFF
--- a/bin/java
+++ b/bin/java
@@ -45,7 +45,7 @@ install_openjdk() {
 			openjdk_version_selector="21"
 
 			output::warning <<-EOF
-				WARNING: No OpenJDK version specified
+				Warning: No OpenJDK version specified
 
 				Your application does not explicitly specify an OpenJDK
 				version. The latest long-term support (LTS) version will be
@@ -65,7 +65,7 @@ install_openjdk() {
 			openjdk_version_selector="1.8"
 
 			output::warning <<-EOF
-				WARNING: No OpenJDK version specified
+				Warning: No OpenJDK version specified
 
 				Your application does not explicitly specify an OpenJDK
 				version. OpenJDK ${openjdk_version_selector} will be installed.
@@ -85,7 +85,7 @@ install_openjdk() {
 
 	if ! openjdk_json=$(inventory::query "${openjdk_version_selector}" "${STACK}"); then
 		output::error <<-EOF
-			ERROR: Unsupported Java version: ${openjdk_version_selector}
+			Error: Unsupported Java version: ${openjdk_version_selector}
 
 			Please check your system.properties file to ensure the java.runtime.version
 			is among the list of supported version on the Dev Center:

--- a/lib/legacy.sh
+++ b/lib/legacy.sh
@@ -21,7 +21,7 @@ legacy::removed_handler() {
 	local function_name="${1}"
 
 	output::error <<-EOF
-		ERROR: Function ${function_name} no longer exposed
+		Error: Function ${function_name} no longer exposed
 
 		The buildpack you're using is likely employing Heroku's jvm-common
 		buildpack to install OpenJDK.

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -107,7 +107,7 @@ RSpec.describe 'Java installation' do
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> JVM Common app detected
           remote: 
-          remote:  !     WARNING: No OpenJDK version specified
+          remote:  !     Warning: No OpenJDK version specified
           remote:  !     
           remote:  !     Your application does not explicitly specify an OpenJDK
           remote:  !     version. The latest long-term support \\(LTS\\) version will be
@@ -139,7 +139,7 @@ RSpec.describe 'Java installation' do
         expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
           remote: -----> JVM Common app detected
           remote: 
-          remote:  !     WARNING: No OpenJDK version specified
+          remote:  !     Warning: No OpenJDK version specified
           remote:  !     
           remote:  !     Your application does not explicitly specify an OpenJDK
           remote:  !     version. OpenJDK 1.8 will be installed.
@@ -174,7 +174,7 @@ RSpec.describe 'Java installation' do
         expect(clean_output(app.output)).to include(<<~OUTPUT)
           remote: -----> JVM Common app detected
           remote: 
-          remote:  !     ERROR: Unsupported Java version: .NET
+          remote:  !     Error: Unsupported Java version: .NET
           remote:  !     
           remote:  !     Please check your system.properties file to ensure the java.runtime.version
           remote:  !     is among the list of supported version on the Dev Center:


### PR DESCRIPTION
## Summary
- Changed "WARNING" to "Warning" and "ERROR" to "Error" in messages
- Aligns message formatting with other JVM buildpacks