### PR TITLE
Change OpenJDK default major version to 25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Support for OpenJDK 25. ([#395](https://github.com/heroku/heroku-buildpack-jvm-common/pull/395))
 
+## Changed
+
+* Default OpenJDK major version on `heroku-24` changed from `21` to `25`. This only applies if no version is specified in `system.properties`. ([#396](https://github.com/heroku/heroku-buildpack-jvm-common/pull/396))
+
 ## [v171] - 2025-09-12
 
 * Add version selection hint to unsupported Java version error message. ([#392](https://github.com/heroku/heroku-buildpack-jvm-common/pull/392))

--- a/bin/java
+++ b/bin/java
@@ -41,8 +41,8 @@ install_openjdk() {
 	if [ -z "${openjdk_version_selector}" ]; then
 		if [ "${STACK}" == "heroku-24" ]; then
 			# This should always be the latest OpenJDK LTS major version
-			# Next LTS will be OpenJDK 25 with a planned release date of 2025-09-16
-			openjdk_version_selector="21"
+			# Next LTS will be OpenJDK 29 (~September 2027, no scheduled release date yet)
+			openjdk_version_selector="25"
 
 			output::warning <<-EOF
 				Warning: No OpenJDK version specified

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -25,7 +25,7 @@ EXPECTED_JAVA_VERSIONS = {
     'heroku-21.0.8' => LATEST_HEROKU_OPENJDK_21_STRING,
   },
   'heroku-24' => {
-    nil => LATEST_ZULU_OPENJDK_21_STRING,
+    nil => LATEST_ZULU_OPENJDK_25_STRING,
     '1.8' => LATEST_ZULU_OPENJDK_8_STRING,
     '8' => LATEST_ZULU_OPENJDK_8_STRING,
     '11' => LATEST_ZULU_OPENJDK_11_STRING,
@@ -111,7 +111,7 @@ RSpec.describe 'Java installation' do
           remote:  !     
           remote:  !     Your application does not explicitly specify an OpenJDK
           remote:  !     version. The latest long-term support \\(LTS\\) version will be
-          remote:  !     installed. This currently is OpenJDK 21.
+          remote:  !     installed. This currently is OpenJDK 25.
           remote:  !     
           remote:  !     This default version will change when a new LTS version is
           remote:  !     released. Your application might fail to build with the new
@@ -121,9 +121,9 @@ RSpec.describe 'Java installation' do
           remote:  !     To set the OpenJDK version, add or edit the system.properties
           remote:  !     file in the root directory of your application to contain:
           remote:  !     
-          remote:  !     java.runtime.version = 21
+          remote:  !     java.runtime.version = 25
           remote: 
-          remote: -----> Installing Azul Zulu OpenJDK 21.0.[0-9]+
+          remote: -----> Installing Azul Zulu OpenJDK 25
           remote: -----> Discovering process types
           remote:        Procfile declares types -> \\(none\\)
         REGEX


### PR DESCRIPTION
Default OpenJDK major version on `heroku-24` changed from `21` to `25`. This only applies if no version is specified in `system.properties`. This is in-line with the policy that the latest LTS release is always the default version installed.

GUS-W-19636322