### PR TITLE
Add additional internal metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+* Additional internal metrics. ([#000]())
 
 ## [v173] - 2025-09-19
 
 ### Added
 
 * Support for automatic Spring AI configuration mapping from Heroku Managed Inference and Agents (MIA) environment variables. ([#398](https://github.com/heroku/heroku-buildpack-jvm-common/pull/398))
-
 
 ## [v172] - 2025-09-17
 

--- a/bin/java
+++ b/bin/java
@@ -102,6 +102,7 @@ install_openjdk() {
 			Heroku
 		EOF
 
+		metrics::conditional_set_string "failure_reason" "unsupported_openjdk_version"
 		return 1
 	fi
 


### PR DESCRIPTION
This PR adds additional internal metrics to track failure reasons when an unsupported OpenJDK version is requested.

Work item: W-19755709