### PR TITLE
Add heroku-26 stack support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,13 +60,13 @@ jobs:
     runs-on: ubuntu-22.04
     needs: lint
     container:
-      image: "${{ fromJson('{ \"heroku-22\": \"heroku/heroku:22\", \"heroku-24\": \"heroku/heroku:24\" }')[matrix.stack] }}"
+      image: "${{ fromJson('{ \"heroku-22\": \"heroku/heroku:22\", \"heroku-24\": \"heroku/heroku:24\", \"heroku-26\": \"heroku/heroku:26\" }')[matrix.stack] }}"
       options: --user root
       env:
         STACK: ${{ matrix.stack }}
     strategy:
       matrix:
-        stack: ["heroku-22", "heroku-24"]
+        stack: ["heroku-22", "heroku-24", "heroku-26"]
     steps:
       - uses: actions/checkout@v6
       - run: test/jdbc.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stack: ["heroku-22", "heroku-24"]
+        stack: ["heroku-22", "heroku-24", "heroku-26"]
     env:
       HATCHET_APP_LIMIT: 100
       PARALLEL_SPLIT_TEST_PROCESSES: 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+
+* Support for the `heroku-26` stack. ([#432](https://github.com/heroku/heroku-buildpack-jvm-common/pull/432))
 
 ## [v179] - 2026-03-18
 

--- a/bin/java
+++ b/bin/java
@@ -63,7 +63,26 @@ install_openjdk() {
 	metrics::conditional_set_string "openjdk_version_selector" "${openjdk_version_selector}"
 
 	if [ -z "${openjdk_version_selector}" ]; then
-		if [ "${STACK}" == "heroku-24" ]; then
+		if [ "${STACK}" == "heroku-22" ]; then
+			openjdk_version_selector="1.8"
+
+			output::warning <<-EOF
+				Warning: No OpenJDK version specified
+
+				Your application does not explicitly specify an OpenJDK
+				version. OpenJDK ${openjdk_version_selector} will be installed.
+
+				This default version will change at some point. Your
+				application might fail to build with the new version. We
+				recommend explicitly setting the required OpenJDK version for
+				your application.
+
+				To set the OpenJDK version, add or edit the system.properties
+				file in the root directory of your application to contain:
+
+				java.runtime.version = ${openjdk_version_selector}
+			EOF
+		else
 			# This should always be the latest OpenJDK LTS major version
 			# Next LTS will be OpenJDK 29 (~September 2027, no scheduled release date yet)
 			openjdk_version_selector="25"
@@ -79,25 +98,6 @@ install_openjdk() {
 				released. Your application might fail to build with the new
 				version. We recommend explicitly setting the required OpenJDK
 				version for your application.
-
-				To set the OpenJDK version, add or edit the system.properties
-				file in the root directory of your application to contain:
-
-				java.runtime.version = ${openjdk_version_selector}
-			EOF
-		else
-			openjdk_version_selector="1.8"
-
-			output::warning <<-EOF
-				Warning: No OpenJDK version specified
-
-				Your application does not explicitly specify an OpenJDK
-				version. OpenJDK ${openjdk_version_selector} will be installed.
-
-				This default version will change at some point. Your
-				application might fail to build with the new version. We
-				recommend explicitly setting the required OpenJDK version for
-				your application.
 
 				To set the OpenJDK version, add or edit the system.properties
 				file in the root directory of your application to contain:

--- a/inventory.json
+++ b/inventory.json
@@ -3223,7 +3223,8 @@
         "distribution": "zulu",
         "cedar_stacks": [
           "heroku-22",
-          "heroku-24"
+          "heroku-24",
+          "heroku-26"
         ]
       }
     },
@@ -3237,7 +3238,8 @@
         "distribution": "zulu",
         "cedar_stacks": [
           "heroku-22",
-          "heroku-24"
+          "heroku-24",
+          "heroku-26"
         ]
       }
     },
@@ -3251,7 +3253,8 @@
         "distribution": "zulu",
         "cedar_stacks": [
           "heroku-22",
-          "heroku-24"
+          "heroku-24",
+          "heroku-26"
         ]
       }
     },
@@ -3265,7 +3268,8 @@
         "distribution": "zulu",
         "cedar_stacks": [
           "heroku-22",
-          "heroku-24"
+          "heroku-24",
+          "heroku-26"
         ]
       }
     },
@@ -3279,7 +3283,8 @@
         "distribution": "zulu",
         "cedar_stacks": [
           "heroku-22",
-          "heroku-24"
+          "heroku-24",
+          "heroku-26"
         ]
       }
     },
@@ -3319,7 +3324,8 @@
         "distribution": "zulu",
         "cedar_stacks": [
           "heroku-22",
-          "heroku-24"
+          "heroku-24",
+          "heroku-26"
         ]
       }
     }

--- a/test/spec/java_spec.rb
+++ b/test/spec/java_spec.rb
@@ -44,6 +44,18 @@ EXPECTED_JAVA_VERSIONS = {
     # Ensure that slightly incorrect version strings work
     '    21 ' => LATEST_ZULU_OPENJDK_21_STRING,
   },
+  'heroku-26' => {
+    nil => LATEST_ZULU_OPENJDK_25_STRING,
+    '1.8' => LATEST_ZULU_OPENJDK_8_STRING,
+    '8' => LATEST_ZULU_OPENJDK_8_STRING,
+    '11' => LATEST_ZULU_OPENJDK_11_STRING,
+    '17' => LATEST_ZULU_OPENJDK_17_STRING,
+    '21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '25' => LATEST_ZULU_OPENJDK_25_STRING,
+    '26' => LATEST_ZULU_OPENJDK_26_STRING,
+    'zulu-21' => LATEST_ZULU_OPENJDK_21_STRING,
+    '21.0.10' => LATEST_ZULU_OPENJDK_21_STRING,
+  },
 }.freeze
 
 # These installed files rarely change so we can check their MD5 hashes
@@ -105,6 +117,38 @@ RSpec.describe 'Java installation' do
   end
 
   context 'when no OpenJDK version is specified on Heroku-24', stacks: %w[heroku-24] do
+    let(:app) { Hatchet::Runner.new('empty') }
+
+    it 'emits the correct warning' do
+      app.deploy do
+        expect(clean_output(app.output)).to match(Regexp.new(<<~REGEX, Regexp::MULTILINE))
+          remote: -----> JVM Common app detected
+          remote:
+          remote:  !     Warning: No OpenJDK version specified
+          remote:  !
+          remote:  !     Your application does not explicitly specify an OpenJDK
+          remote:  !     version. The latest long-term support \\(LTS\\) version will be
+          remote:  !     installed. This currently is OpenJDK 25.
+          remote:  !
+          remote:  !     This default version will change when a new LTS version is
+          remote:  !     released. Your application might fail to build with the new
+          remote:  !     version. We recommend explicitly setting the required OpenJDK
+          remote:  !     version for your application.
+          remote:  !
+          remote:  !     To set the OpenJDK version, add or edit the system.properties
+          remote:  !     file in the root directory of your application to contain:
+          remote:  !
+          remote:  !     java.runtime.version = 25
+          remote:
+          remote: -----> Installing Azul Zulu OpenJDK 25.0.[0-9]+
+          remote: -----> Discovering process types
+          remote:        Procfile declares types -> \\(none\\)
+        REGEX
+      end
+    end
+  end
+
+  context 'when no OpenJDK version is specified on Heroku-26', stacks: %w[heroku-26] do
     let(:app) { Hatchet::Runner.new('empty') }
 
     it 'emits the correct warning' do


### PR DESCRIPTION
Adds `heroku-26` stack support to the JVM buildpack. Since heroku-26 only supports Azul Zulu OpenJDK, `heroku-26` was added to the `cedar_stacks` of all current zulu inventory entries (`1.8.0_482`, `11.0.30`, `17.0.18`, `21.0.10`, `25.0.2`, `26`). No heroku distribution entries are needed.

The default version condition in `bin/java` was flipped so `heroku-22` is the special case that defaults to `1.8` — all other stacks now default to the latest LTS without needing code changes for future stacks.

GUS-W-20775991